### PR TITLE
New : Tambah tombol Copy di tabel Ticket untuk membuat tiket baru dengan data terisi otomatis

### DIFF
--- a/app/Filament/Resources/TicketResource.php
+++ b/app/Filament/Resources/TicketResource.php
@@ -12,6 +12,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Filament\Tables\Actions\Action;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use App\Models\Epic;
@@ -331,6 +332,18 @@ class TicketResource extends Resource
             ->actions([
                 Tables\Actions\ViewAction::make(),
                 Tables\Actions\EditAction::make(),
+                Action::make('copy')
+                    ->label('Copy')
+                    ->icon('heroicon-o-document-duplicate')
+                    ->color('info')
+                    ->action(function ($record, $livewire) {
+                        // Redirect ke halaman create, dengan parameter copy_from
+                        return $livewire->redirect(
+                            static::getUrl('create', [
+                                'copy_from' => $record->id,
+                            ])
+                        );
+                    }),
             ])
             ->bulkActions([
                 Tables\Actions\BulkActionGroup::make([


### PR DESCRIPTION
# New: Tambah tombol copy di tabel ticket

PR ini menambahkan tombol **Copy** di tabel Ticket.  
Dengan fitur ini, pengguna bisa membuat tiket baru berdasarkan tiket yang sudah ada tanpa harus mengisi ulang semua data dari awal.

---

## Sebelum
- Tidak ada tombol **Copy** di tabel Ticket.  
- Jika ingin membuat tiket serupa, pengguna harus membuat tiket baru dan mengisi semua field secara manual.  

---

## Sesudah
- Tersedia tombol **Copy** di setiap baris tabel Ticket.  
- Saat diklik, pengguna diarahkan ke halaman **Create Ticket** dengan parameter `copy_from`.  
- Form **Create Ticket** otomatis terisi dengan data dari tiket yang dicopy (project, status, priority, epic, deskripsi, assignees, dll).  
- Field sensitif seperti `id`, `uuid`, `created_at`, `updated_at`, dan `created_by` **tidak ikut dicopy**.  

---
<img width="649" height="319" alt="image" src="https://github.com/user-attachments/assets/7fa99bb3-6a23-497b-aca0-f4ac46d478e8" />
