### PR TITLE
implements Filament User and dynamic role checking

### DIFF
--- a/app/Models/Roles.php
+++ b/app/Models/Roles.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Roles extends Model
+{
+    protected $fillable = ['name', 'guard_name'];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -10,7 +12,7 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
     use HasFactory, HasRoles, Notifiable;
@@ -94,5 +96,11 @@ class User extends Authenticatable
     public function getUnreadNotificationsCountAttribute(): int
     {
         return $this->unreadNotifications()->count();
+    }
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        $roles = Roles::all()->pluck('name')->toArray();
+        return $this->hasAnyRole($roles);
     }
 }


### PR DESCRIPTION
This PR resolves the 403 Forbidden error that occurs when logging in on a Production Environment. 

As stated on the Filament Documentation here [Filament User in Production](https://filamentphp.com/docs/4.x/users/overview#introduction), to allow users to access Filament in Production, we must implement the FilamentUser contract on the User Model.


I implemented the FilamentUser Contract and added dynamic Role checking to the canAccessPanel function to authorize roles created by the Super Admin.
