### PR TITLE
Improve: Change create ticket on Project Board to modal

### DIFF
--- a/app/Filament/Resources/Tickets/TicketResource.php
+++ b/app/Filament/Resources/Tickets/TicketResource.php
@@ -2,45 +2,42 @@
 
 namespace App\Filament\Resources\Tickets;
 
-use Filament\Schemas\Schema;
-use Filament\Forms\Components\Select;
-use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\RichEditor;
-use Filament\Forms\Components\DatePicker;
-use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Filters\SelectFilter;
-use Filament\Tables\Filters\Filter;
-use Filament\Actions\ViewAction;
-use Filament\Actions\EditAction;
+use App\Filament\Resources\Tickets\Pages\CreateTicket;
+use App\Filament\Resources\Tickets\Pages\EditTicket;
+use App\Filament\Resources\Tickets\Pages\ListTickets;
+use App\Filament\Resources\Tickets\Pages\ViewTicket;
+use App\Models\Epic;
+use App\Models\Project;
+use App\Models\Ticket;
+use App\Models\TicketPriority;
+use App\Models\TicketStatus;
 use Filament\Actions\Action;
 use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteBulkAction;
-use App\Filament\Resources\Tickets\Pages\ListTickets;
-use App\Filament\Resources\Tickets\Pages\CreateTicket;
-use App\Filament\Resources\Tickets\Pages\ViewTicket;
-use App\Filament\Resources\Tickets\Pages\EditTicket;
-use App\Filament\Resources\TicketResource\Pages;
-use App\Models\Project;
-use App\Models\Ticket;
-use App\Models\TicketStatus;
-use App\Models\TicketPriority;
-use Filament\Forms;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Resources\Resource;
-use Filament\Tables;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Collection;
-use App\Models\Epic;
 
 class TicketResource extends Resource
 {
     protected static ?string $model = Ticket::class;
 
-    protected static string | \BackedEnum | null $navigationIcon = 'heroicon-o-ticket';
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-ticket';
 
     protected static ?string $navigationLabel = 'Tickets';
 
-    protected static string | \UnitEnum | null $navigationGroup = 'Project Management';
+    protected static string|\UnitEnum|null $navigationGroup = 'Project Management';
 
     protected static ?int $navigationSort = 5;
 
@@ -51,8 +48,8 @@ class TicketResource extends Resource
         if (! auth()->user()->hasRole(['super_admin'])) {
             $query->where(function ($query) {
                 $query->whereHas('assignees', function ($query) {
-                        $query->where('users.id', auth()->id());
-                    })
+                    $query->where('users.id', auth()->id());
+                })
                     ->orWhere('created_by', auth()->id())
                     ->orWhereHas('project.members', function ($query) {
                         $query->where('users.id', auth()->id());
@@ -80,6 +77,8 @@ class TicketResource extends Resource
                         return auth()->user()->projects()->pluck('name', 'projects.id')->toArray();
                     })
                     ->default($projectId)
+                    ->disabledOn('ticket_on_board')
+                    ->dehydrated()
                     ->required()
                     ->searchable()
                     ->preload()
@@ -116,13 +115,13 @@ class TicketResource extends Resource
 
                 Select::make('epic_id')
                     ->label('Epic')
-                    ->options(function (callable $get) {
+                    ->options(function (Get $get) {
                         $projectId = $get('project_id');
-                        
-                        if (!$projectId) {
+
+                        if (! $projectId) {
                             return [];
                         }
-                        
+
                         return Epic::where('project_id', $projectId)
                             ->pluck('name', 'id')
                             ->toArray();
@@ -130,7 +129,7 @@ class TicketResource extends Resource
                     ->searchable()
                     ->preload()
                     ->nullable()
-                    ->hidden(fn (callable $get): bool => !$get('project_id')),
+                    ->hidden(fn (Get $get): bool => ! $get('project_id')),
 
                 TextInput::make('name')
                     ->label('Ticket Name')
@@ -142,14 +141,14 @@ class TicketResource extends Resource
                     ->fileAttachmentsDirectory('attachments')
                     ->columnSpanFull(),
 
-                // Multi-user assignment
+                // // Multi-user assignment
                 Select::make('assignees')
                     ->label('Assigned to')
                     ->multiple()
                     ->relationship(
                         name: 'assignees',
                         titleAttribute: 'name',
-                        modifyQueryUsing: function (Builder $query, callable $get) {
+                        modifyQueryUsing: function (Builder $query, Get $get) {
                             $projectId = $get('project_id');
                             if (! $projectId) {
                                 return $query->whereRaw('1 = 0');
@@ -168,14 +167,14 @@ class TicketResource extends Resource
                     ->searchable()
                     ->preload()
                     ->helperText('Select multiple users to assign this ticket to. Only project members can be assigned.')
-                    ->hidden(fn (callable $get): bool => !$get('project_id'))
+                    ->hidden(fn (Get $get): bool => ! $get('project_id'))
                     ->live(),
-                
+
                 DatePicker::make('start_date')
                     ->label('Start Date')
                     ->default(now())
                     ->nullable(),
-                
+
                 DatePicker::make('due_date')
                     ->label('Due Date')
                     ->nullable(),
@@ -183,7 +182,7 @@ class TicketResource extends Resource
                     ->label('Created By')
                     ->relationship('creator', 'name')
                     ->disabled()
-                    ->hiddenOn('create'),
+                    ->hiddenOn(['create', 'ticket_on_board']),
             ]);
     }
 
@@ -248,7 +247,7 @@ class TicketResource extends Resource
                     ->label('Due Date')
                     ->date()
                     ->sortable(),
-                    
+
                 TextColumn::make('epic.name')
                     ->label('Epic')
                     ->sortable()
@@ -268,37 +267,37 @@ class TicketResource extends Resource
                         if (auth()->user()->hasRole(['super_admin'])) {
                             return Project::pluck('name', 'id')->toArray();
                         }
-            
+
                         return auth()->user()->projects()->pluck('name', 'projects.id')->toArray();
                     })
                     ->searchable()
                     ->preload(),
-            
+
                 SelectFilter::make('ticket_status_id')
                     ->label('Status')
                     ->options(function () {
                         $projectId = request()->input('tableFilters.project_id');
-                        
-                        if (!$projectId) {
+
+                        if (! $projectId) {
                             return [];
                         }
-                        
+
                         return TicketStatus::where('project_id', $projectId)
                             ->pluck('name', 'id')
                             ->toArray();
                     })
                     ->searchable()
                     ->preload(),
-                    
+
                 SelectFilter::make('epic_id')
                     ->label('Epic')
                     ->options(function () {
                         $projectId = request()->input('tableFilters.project_id');
-                        
-                        if (!$projectId) {
+
+                        if (! $projectId) {
                             return [];
                         }
-                        
+
                         return Epic::where('project_id', $projectId)
                             ->pluck('name', 'id')
                             ->toArray();
@@ -326,7 +325,7 @@ class TicketResource extends Resource
                     ->relationship('creator', 'name')
                     ->searchable()
                     ->preload(),
-            
+
                 Filter::make('due_date')
                     ->schema([
                         DatePicker::make('due_from'),


### PR DESCRIPTION
This PR changes the ticket creation process on the project board from opening a new tab to opening a modal, so users can create tickets directly on the project board without switching tabs.