### PR TITLE
Add selectable All Projects view to Project Board

### DIFF
--- a/app/Exports/TicketsExport.php
+++ b/app/Exports/TicketsExport.php
@@ -2,26 +2,28 @@
 
 namespace App\Exports;
 
-use PhpOffice\PhpSpreadsheet\Style\Fill;
-use App\Models\Ticket;
+use Illuminate\Support\Collection;
 use Maatwebsite\Excel\Concerns\FromCollection;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 use Maatwebsite\Excel\Concerns\WithHeadings;
 use Maatwebsite\Excel\Concerns\WithMapping;
 use Maatwebsite\Excel\Concerns\WithStyles;
-use Maatwebsite\Excel\Concerns\ShouldAutoSize;
+use PhpOffice\PhpSpreadsheet\Style\Fill;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
-use Illuminate\Support\Collection;
 
-class TicketsExport implements FromCollection, WithHeadings, WithMapping, WithStyles, ShouldAutoSize
+class TicketsExport implements FromCollection, ShouldAutoSize, WithHeadings, WithMapping, WithStyles
 {
     protected $tickets;
+
     protected $selectedColumns;
+
     protected $availableColumns = [
         'uuid' => 'Ticket ID',
         'name' => 'Title',
         'description' => 'Description',
         'status' => 'Status',
         'assignee' => 'Assignee',
+        'project_code' => 'Project Code',
         'project' => 'Project',
         'epic' => 'Epic',
         'start_date' => 'Start Date',
@@ -49,6 +51,7 @@ class TicketsExport implements FromCollection, WithHeadings, WithMapping, WithSt
                 $headings[] = $this->availableColumns[$column];
             }
         }
+
         return $headings;
     }
 
@@ -71,7 +74,10 @@ class TicketsExport implements FromCollection, WithHeadings, WithMapping, WithSt
                     $row[] = $ticket->status?->name ?? 'No Status';
                     break;
                 case 'assignee':
-                    $row[] = $ticket->assignees->pluck('name')->implode(', ');;
+                    $row[] = $ticket->assignees->pluck('name')->implode(', ');
+                    break;
+                case 'project_code':
+                    $row[] = $this->projectCode($ticket->project);
                     break;
                 case 'project':
                     $row[] = $ticket->project?->name ?? 'No Project';
@@ -127,5 +133,31 @@ class TicketsExport implements FromCollection, WithHeadings, WithMapping, WithSt
     public function getAvailableColumns(): array
     {
         return $this->availableColumns;
+    }
+
+    private function projectCode($project): string
+    {
+        if (! $project) {
+            return 'PRJ';
+        }
+
+        if ($project->ticket_prefix) {
+            return $project->ticket_prefix;
+        }
+
+        $words = str($project->name)
+            ->replaceMatches('/[^A-Za-z0-9\s]/', ' ')
+            ->squish()
+            ->explode(' ')
+            ->filter();
+
+        if ($words->count() <= 1) {
+            return str($project->name)->upper()->substr(0, 4)->toString();
+        }
+
+        return $words
+            ->take(4)
+            ->map(fn (string $word) => str($word)->substr(0, 1)->upper()->toString())
+            ->implode('');
     }
 }

--- a/app/Filament/Actions/ExportTicketsAction.php
+++ b/app/Filament/Actions/ExportTicketsAction.php
@@ -2,13 +2,9 @@
 
 namespace App\Filament\Actions;
 
-use Filament\Schemas\Components\Section;
-use App\Exports\TicketsExport;
 use Filament\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
-use Filament\Notifications\Notification;
-use Maatwebsite\Excel\Facades\Excel;
-use Symfony\Component\HttpFoundation\StreamedResponse;
+use Filament\Schemas\Components\Section;
 
 class ExportTicketsAction
 {
@@ -30,18 +26,19 @@ class ExportTicketsAction
                                 'description' => 'Description',
                                 'status' => 'Status',
                                 'assignee' => 'Assignee',
+                                'project_code' => 'Project Code',
                                 'project' => 'Project',
                                 'epic' => 'Epic',
                                 'due_date' => 'Due Date',
                                 'created_at' => 'Created At',
                                 'updated_at' => 'Updated At',
                             ])
-                            ->default(['uuid', 'name', 'status', 'assignee', 'due_date', 'created_at'])
+                            ->default(['uuid', 'name', 'status', 'assignee', 'project_code', 'project', 'due_date', 'created_at'])
                             ->required()
                             ->minItems(1)
                             ->columns(2)
-                            ->gridDirection('row')
-                    ])
+                            ->gridDirection('row'),
+                    ]),
             ])
             ->action(function (array $data, $livewire): void {
                 $livewire->exportTickets($data['columns'] ?? []);

--- a/app/Filament/Pages/ProjectBoard.php
+++ b/app/Filament/Pages/ProjectBoard.php
@@ -7,12 +7,14 @@ use App\Filament\Actions\ExportTicketsAction;
 use App\Filament\Resources\Tickets\TicketResource;
 use App\Models\Project;
 use App\Models\Ticket;
+use App\Models\TicketStatus;
 use App\Models\User;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Computed;
@@ -21,6 +23,22 @@ use Maatwebsite\Excel\Facades\Excel;
 
 class ProjectBoard extends Page
 {
+    private const MODE_GLOBAL = 'global';
+
+    private const MODE_INDEX = 'index';
+
+    private const MODE_PROJECT = 'project';
+
+    private const ALL_PROJECT_ROUTE = 'all-project';
+
+    private const SELECTED_PROJECTS_ROUTE_PREFIX = 'selected-projects-';
+
+    private const SESSION_SELECTED_GLOBAL_PROJECT_IDS = 'project_board.selected_global_project_ids';
+
+    private const DEFAULT_COLUMN_LIMIT = 20;
+
+    private const COLUMN_LIMIT_INCREMENT = 20;
+
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-view-columns';
 
     protected string $view = 'filament.pages.project-board';
@@ -50,9 +68,15 @@ class ProjectBoard extends Page
 
     public ?int $selectedProjectId = null;
 
+    public string $boardMode = self::MODE_INDEX;
+
     public array $sortOrders = [];
 
+    public array $columnLimits = [];
+
     public array $selectedUserIds = [];
+
+    public array $selectedGlobalProjectIds = [];
 
     public Collection $projectUsers;
 
@@ -60,26 +84,54 @@ class ProjectBoard extends Page
 
     public function mount($project_id = null): void
     {
-        if (auth()->user()->hasRole(['super_admin'])) {
-            $this->projects = Project::orderByRaw('pinned_date IS NULL')
-                ->orderBy('pinned_date', 'desc')
-                ->orderBy('name')
-                ->get();
-        } else {
-            $this->projects = auth()->user()->projects()
-                ->orderByRaw('pinned_date IS NULL')
-                ->orderBy('pinned_date', 'desc')
-                ->orderBy('name')
-                ->get();
+        $this->loadProjects();
+        $this->projectUsers = collect();
+
+        if ($project_id === null || $project_id === '') {
+            if ($this->restorePersistedGlobalProjectFilter()) {
+                return;
+            }
+
+            $this->showProjectIndex(navigate: false);
+
+            return;
         }
 
-        if ($project_id) {
-            $this->selectedProjectId = (int) $project_id;
-            $this->selectedProject = Project::find($project_id);
-            $this->loadProjectUsers();
-        } else {
-            $this->projectUsers = collect();
+        $routeProjectId = (string) $project_id;
+
+        if ($routeProjectId === self::ALL_PROJECT_ROUTE) {
+            $this->selectAllProjects(navigate: false);
+
+            return;
         }
+
+        if (str_starts_with($routeProjectId, self::SELECTED_PROJECTS_ROUTE_PREFIX)) {
+            $this->selectSelectedProjects($this->selectedProjectIdsFromRoute($routeProjectId), navigate: false);
+
+            return;
+        }
+
+        if (is_numeric($routeProjectId)) {
+            $this->selectProject((int) $routeProjectId, navigate: false);
+
+            return;
+        }
+
+        $this->showProjectIndex(navigate: false);
+    }
+
+    private function loadProjects(): void
+    {
+        $query = auth()->user()->hasRole(['super_admin'])
+            ? Project::query()
+            : auth()->user()->projects();
+
+        $this->projects = $query
+            ->select('projects.id', 'projects.name', 'projects.ticket_prefix', 'projects.color', 'projects.pinned_date')
+            ->orderByRaw('pinned_date IS NULL')
+            ->orderBy('pinned_date', 'desc')
+            ->orderBy('name')
+            ->get();
     }
 
     public function getFilteredProjectsProperty(): Collection
@@ -97,71 +149,131 @@ class ProjectBoard extends Page
     public function updatedSelectedProjectId($value): void
     {
         if ($value) {
-            $this->selectProject($value);
+            $this->selectProject((int) $value);
         } else {
-            $this->selectedProject = null;
-            $this->projectUsers = collect();
-            $this->selectedUserIds = [];
-
-            // Use wire:navigate for SPA-like navigation
-            $url = static::getUrl();
-            $this->js("Livewire.navigate('{$url}')");
+            $this->showProjectIndex();
         }
     }
 
-    public function selectProject(int $projectId): void
+    public function showProjectIndex(bool $navigate = true): void
     {
+        $this->clearPersistedGlobalProjectFilter();
+        $this->boardMode = self::MODE_INDEX;
         $this->selectedTicket = null;
-        $this->ticketStatuses = collect();
-        $this->selectedProjectId = $projectId;
-        $this->selectedProject = Project::with('tickets')->find($projectId);
+        $this->selectedProject = null;
+        $this->selectedProjectId = null;
+        $this->selectedGlobalProjectIds = [];
+        $this->projectUsers = collect();
         $this->selectedUserIds = [];
+        $this->columnLimits = [];
+        $this->loadTicketStatuses();
+
+        if ($navigate) {
+            $this->navigateToBoardUrl();
+        }
+    }
+
+    public function selectAllProjects(bool $navigate = true): void
+    {
+        $this->clearPersistedGlobalProjectFilter();
+        $this->boardMode = self::MODE_GLOBAL;
+        $this->selectedTicket = null;
+        $this->selectedProject = null;
+        $this->selectedProjectId = null;
+        $this->selectedGlobalProjectIds = [];
+        $this->projectUsers = collect();
+        $this->selectedUserIds = [];
+        $this->columnLimits = [];
+        $this->loadProjectUsers();
+        $this->loadTicketStatuses();
+
+        if ($navigate) {
+            $this->navigateToBoardUrl(self::ALL_PROJECT_ROUTE);
+        }
+    }
+
+    public function selectSelectedProjects(array $projectIds, bool $navigate = true): void
+    {
+        $this->boardMode = self::MODE_GLOBAL;
+        $this->selectedTicket = null;
+        $this->selectedProject = null;
+        $this->selectedProjectId = null;
+        $this->selectedGlobalProjectIds = $this->normalizedGlobalProjectFilterIds($projectIds);
+        $this->projectUsers = collect();
+        $this->selectedUserIds = [];
+        $this->columnLimits = [];
+        $this->loadProjectUsers();
+        $this->loadTicketStatuses();
+        $this->persistGlobalProjectFilter();
+
+        if ($navigate) {
+            $this->navigateToBoardUrl($this->globalRouteParameter());
+        }
+    }
+
+    public function selectProject(int $projectId, bool $navigate = true): void
+    {
+        $this->clearPersistedGlobalProjectFilter();
+        $this->boardMode = self::MODE_PROJECT;
+        $this->selectedTicket = null;
+        $this->selectedProjectId = $projectId;
+        $this->selectedProject = $this->projects->firstWhere('id', $projectId);
+        $this->selectedGlobalProjectIds = [];
+        $this->selectedUserIds = [];
+        $this->columnLimits = [];
 
         if ($this->selectedProject) {
             $this->loadProjectUsers();
+            $this->loadTicketStatuses();
 
             // Use wire:navigate for SPA-like navigation
-            $url = static::getUrl(['project_id' => $projectId]);
-            $this->js("Livewire.navigate('{$url}')");
+            if ($navigate) {
+                $this->navigateToBoardUrl((string) $projectId);
+            }
+
+            return;
         }
+
+        $this->showProjectIndex(navigate: false);
     }
 
     #[Computed]
     public function ticketStatuses(): Collection
     {
+        if ($this->isGlobalBoard()) {
+            return $this->globalBoardColumns();
+        }
+
         if (! $this->selectedProject) {
             return collect();
         }
 
+        return $this->projectBoardColumns();
+    }
+
+    private function projectBoardColumns(): Collection
+    {
         $statuses = $this->selectedProject->ticketStatuses()
-            ->with([
-                'tickets' => function ($query) {
-                    $query->with([
-                        'assignees:id,name',
-                        'status:id,name,color,is_completed',
-                        'priority:id,name,color',
-                        'creator:id,name',
-                    ])
-                        ->select('id', 'project_id', 'ticket_status_id', 'priority_id', 'name', 'description', 'uuid', 'due_date', 'created_at', 'updated_at', 'created_by')
-                        ->when(! empty($this->selectedUserIds), function ($query) {
-                            $query->whereHas('assignees', function ($assigneeQuery) {
-                                $assigneeQuery->whereIn('users.id', $this->selectedUserIds);
-                            });
-                        })
-                        ->orderByDesc('created_at')
-                        ->orderByDesc('id');
-                },
-            ])
             ->select('id', 'project_id', 'name', 'color', 'sort_order', 'is_completed')
             ->orderBy('sort_order')
             ->get();
 
-        $statuses->each(function ($status) {
+        return $statuses->map(function ($status) {
             $sortOrder = $this->sortOrders[$status->id] ?? 'date_created_newest';
-            $status->tickets = $this->applySorting($status->tickets, $sortOrder);
-        });
+            $baseQuery = $this->projectTicketsQuery($status->id);
 
-        return $statuses;
+            $status->tickets_count = (clone $baseQuery)->count();
+            $status->tickets = $this->applyQuerySorting(
+                (clone $baseQuery)
+                    ->with($this->ticketRelations())
+                    ->select($this->ticketSelectColumns()),
+                $sortOrder
+            )
+                ->limit($this->getColumnLimit($status->id))
+                ->get();
+
+            return $status;
+        });
     }
 
     public function loadTicketStatuses(): void
@@ -172,23 +284,27 @@ class ProjectBoard extends Page
 
     public function loadProjectUsers(): void
     {
-        if (! $this->selectedProject) {
+        if ($this->isProjectIndex()) {
             $this->projectUsers = collect();
 
             return;
         }
 
-        // Get only users who are assigned to tickets in this project
-        $ticketAssigneeIds = $this->selectedProject->tickets()
-            ->with('assignees')
-            ->get()
-            ->flatMap(function ($ticket) {
-                return $ticket->assignees->pluck('id');
-            })
-            ->unique()
-            ->filter();
+        $projectIds = $this->selectedProject
+            ? [$this->selectedProject->id]
+            : $this->visibleGlobalProjectIds();
 
-        $this->projectUsers = User::whereIn('id', $ticketAssigneeIds)
+        if (empty($projectIds)) {
+            $this->projectUsers = collect();
+
+            return;
+        }
+
+        $this->projectUsers = User::query()
+            ->select('users.id', 'users.name')
+            ->whereHas('assignedTickets', function (Builder $query) use ($projectIds) {
+                $query->whereIn('tickets.project_id', $projectIds);
+            })
             ->orderBy('name')
             ->get();
     }
@@ -210,29 +326,28 @@ class ProjectBoard extends Page
         $this->loadTicketStatuses();
     }
 
-    private function applySorting($tickets, $sortOrder)
+    public function loadMoreTickets(string $columnId): void
+    {
+        $this->columnLimits[$columnId] = $this->getColumnLimit($columnId) + self::COLUMN_LIMIT_INCREMENT;
+        $this->loadTicketStatuses();
+        $this->dispatch('ticket-updated');
+    }
+
+    private function applyQuerySorting(Builder $query, string $sortOrder): Builder
     {
         switch ($sortOrder) {
             case 'date_created_newest':
-                // Query already ordered by created_at DESC, id DESC - just reset keys
-                return $tickets->values();
+                return $query->orderByDesc('created_at')->orderByDesc('id');
             case 'date_created_oldest':
-                return $tickets->sortBy(function ($ticket) {
-                    return $ticket->created_at->timestamp . '_' . str_pad($ticket->id, 10, '0', STR_PAD_LEFT);
-                })->values();
+                return $query->orderBy('created_at')->orderBy('id');
             case 'card_name_alphabetical':
-                return $tickets->sortBy('name')->values();
+                return $query->orderBy('name')->orderByDesc('created_at');
             case 'due_date':
-                return $tickets->sortBy(function ($ticket) {
-                    return $ticket->due_date ?? '9999-12-31';
-                })->values();
+                return $query->orderByRaw('due_date IS NULL')->orderBy('due_date')->orderByDesc('created_at');
             case 'priority':
-                return $tickets->sortBy(function ($ticket) {
-                    return $ticket->priority ? $ticket->priority->id : 999;
-                })->values();
+                return $query->orderByRaw('priority_id IS NULL')->orderBy('priority_id')->orderByDesc('created_at');
             default:
-                // Default is same as date_created_newest - query already sorted
-                return $tickets->values();
+                return $query->orderByDesc('created_at')->orderByDesc('id');
         }
     }
 
@@ -241,30 +356,53 @@ class ProjectBoard extends Page
     {
         $ticket = Ticket::find($ticketId);
 
-        if ($ticket && $ticket->project_id === $this->selectedProject?->id) {
-            if (! $this->canManageTicket($ticket)) {
-                Notification::make()
-                    ->title('Permission Denied')
-                    ->body('You do not have permission to move this ticket.')
-                    ->danger()
-                    ->send();
-
-                return;
-            }
-
-            $ticket->update([
-                'ticket_status_id' => $newStatusId,
-            ]);
-
-            $this->loadTicketStatuses();
-
-            $this->dispatch('ticket-updated');
-
+        if (! $ticket) {
             Notification::make()
-                ->title('Ticket Updated')
-                ->success()
+                ->title('Ticket Not Found')
+                ->danger()
                 ->send();
+
+            return;
         }
+
+        if (! $this->canManageTicket($ticket)) {
+            Notification::make()
+                ->title('Permission Denied')
+                ->body('You do not have permission to move this ticket.')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        $targetStatus = $this->resolveTargetStatus($ticket, (string) $newStatusId);
+
+        if (! $targetStatus) {
+            Notification::make()
+                ->title('Status Not Found')
+                ->body("This ticket's project does not have that exact status.")
+                ->warning()
+                ->send();
+
+            return;
+        }
+
+        if ($ticket->ticket_status_id === $targetStatus->id) {
+            return;
+        }
+
+        $ticket->update([
+            'ticket_status_id' => $targetStatus->id,
+        ]);
+
+        $this->loadTicketStatuses();
+
+        $this->dispatch('ticket-updated');
+
+        Notification::make()
+            ->title('Ticket Updated')
+            ->success()
+            ->send();
     }
 
     #[On('refresh-board')]
@@ -361,14 +499,58 @@ class ProjectBoard extends Page
                 ->label('Refresh Board')
                 ->icon('heroicon-m-arrow-path')
                 ->action('refreshBoard')
+                ->visible(fn () => ! $this->isProjectIndex())
                 ->color('warning'),
+            Action::make('filter_projects')
+                ->label(fn () => $this->projectFilterActionLabel())
+                ->icon('heroicon-m-funnel')
+                ->visible(fn () => ($this->isProjectIndex() || $this->isGlobalBoard()) && $this->projects->isNotEmpty())
+                ->schema([
+                    CheckboxList::make('selectedGlobalProjectIds')
+                        ->label('Projects to Show')
+                        ->helperText('Leave empty to show every accessible project.')
+                        ->options(fn () => $this->projectFilterOptionLabels())
+                        ->allowHtml()
+                        ->columns(2)
+                        ->searchable()
+                        ->bulkToggleable(),
+                ])
+                ->action(function (array $data) {
+                    $selectedProjectIds = $this->normalizedGlobalProjectFilterIds($data['selectedGlobalProjectIds'] ?? []);
+
+                    if (empty($selectedProjectIds)) {
+                        $this->selectAllProjects();
+                    } else {
+                        $this->selectSelectedProjects($selectedProjectIds);
+                    }
+
+                    $projectCount = count($selectedProjectIds);
+                    if ($projectCount > 0) {
+                        Notification::make()
+                            ->title('Project Filter Applied')
+                            ->body("Showing tickets for {$projectCount} selected project(s).")
+                            ->success()
+                            ->send();
+                    } else {
+                        Notification::make()
+                            ->title('Project Filter Cleared')
+                            ->body('Showing tickets from all accessible projects.')
+                            ->info()
+                            ->send();
+                    }
+                })
+                ->fillForm(fn () => [
+                    'selectedGlobalProjectIds' => $this->normalizedGlobalProjectFilterIds($this->selectedGlobalProjectIds),
+                ])
+                ->modalWidth('lg')
+                ->color('gray'),
             ExportTicketsAction::make()
-                ->visible(fn () => $this->selectedProject !== null && auth()->user()->hasRole(['super_admin'])),
+                ->visible(fn () => ! $this->isProjectIndex() && auth()->user()->hasRole(['super_admin'])),
 
             Action::make('filter_users')
                 ->label('Filter by User')
                 ->icon('heroicon-m-user-group')
-                ->visible(fn () => $this->selectedProject !== null && $this->projectUsers->isNotEmpty())
+                ->visible(fn () => ! $this->isProjectIndex() && $this->projectUsers->isNotEmpty())
                 ->schema([
                     CheckboxList::make('selectedUserIds')
                         ->label('Select Users to Filter')
@@ -415,8 +597,8 @@ class ProjectBoard extends Page
         }
 
         return auth()->user()->hasRole(['super_admin'])
-            || $ticket->user_id === auth()->id()
-            || $ticket->assignees()->where('users.id', auth()->id())->exists();
+            || $ticket->created_by === auth()->id()
+            || $this->userIsTicketAssignee($ticket);
     }
 
     private function canEditTicket(?Ticket $ticket): bool
@@ -435,8 +617,8 @@ class ProjectBoard extends Page
         // 2. The ticket creator
         // 3. Assigned to the ticket
         return auth()->user()->hasRole(['super_admin'])
-            || $ticket->user_id === auth()->id()
-            || $ticket->assignees()->where('users.id', auth()->id())->exists();
+            || $ticket->created_by === auth()->id()
+            || $this->userIsTicketAssignee($ticket);
     }
 
     private function canManageTicket(?Ticket $ticket): bool
@@ -449,8 +631,22 @@ class ProjectBoard extends Page
         }
 
         return auth()->user()->hasRole(['super_admin'])
-            || $ticket->user_id === auth()->id()
-            || $ticket->assignees()->where('users.id', auth()->id())->exists();
+            || $ticket->created_by === auth()->id()
+            || $this->userIsTicketAssignee($ticket);
+    }
+
+    public function canMoveTicket(?Ticket $ticket): bool
+    {
+        return $this->canManageTicket($ticket);
+    }
+
+    private function userIsTicketAssignee(Ticket $ticket): bool
+    {
+        if ($ticket->relationLoaded('assignees')) {
+            return $ticket->assignees->contains('id', auth()->id());
+        }
+
+        return $ticket->assignees()->where('users.id', auth()->id())->exists();
     }
 
     public function exportTickets(array $selectedColumns): void
@@ -465,21 +661,45 @@ class ProjectBoard extends Page
             return;
         }
 
-        $tickets = collect();
+        if ($this->isGlobalBoard()) {
+            $insertAfter = array_search('assignee', $selectedColumns, true);
+            $insertAt = $insertAfter === false ? 0 : $insertAfter + 1;
+            $requiredProjectColumns = array_values(array_filter(
+                ['project_code', 'project'],
+                fn (string $column) => ! in_array($column, $selectedColumns, true)
+            ));
+
+            if (! empty($requiredProjectColumns)) {
+                array_splice($selectedColumns, $insertAt, 0, $requiredProjectColumns);
+            }
+        }
 
         if ($this->selectedProject) {
-            $tickets = $this->selectedProject->tickets()
+            $tickets = Ticket::query()
+                ->where('project_id', $this->selectedProject->id)
+                ->when(! empty($this->selectedUserIds), function (Builder $query) {
+                    $query->whereHas('assignees', function (Builder $assigneeQuery) {
+                        $assigneeQuery->whereIn('users.id', $this->selectedUserIds);
+                    });
+                })
                 ->with(['assignees', 'status', 'project', 'epic'])
                 ->orderBy('created_at', 'desc')
                 ->get();
-        } elseif ($this->ticketStatuses->isNotEmpty()) {
-            $ticketIds = $this->ticketStatuses->flatMap(function ($status) {
-                return $status->tickets->pluck('id');
-            });
-
-            $tickets = Ticket::whereIn('id', $ticketIds)
+        } else {
+            $projectIds = $this->visibleGlobalProjectIds();
+            $tickets = Ticket::query()
+                ->when(
+                    empty($projectIds),
+                    fn (Builder $query) => $query->whereRaw('1 = 0'),
+                    fn (Builder $query) => $query->whereIn('project_id', $projectIds)
+                )
+                ->when(! empty($this->selectedUserIds), function (Builder $query) {
+                    $query->whereHas('assignees', function (Builder $assigneeQuery) {
+                        $assigneeQuery->whereIn('users.id', $this->selectedUserIds);
+                    });
+                })
                 ->with(['assignees', 'status', 'project', 'epic'])
-                ->orderBy('created_at', 'asc')
+                ->orderBy('created_at', 'desc')
                 ->get();
         }
 
@@ -494,7 +714,8 @@ class ProjectBoard extends Page
         }
 
         try {
-            $fileName = 'tickets_'.($this->selectedProject?->name ?? 'export').'_'.now()->format('Y-m-d_H-i-s').'.xlsx';
+            $globalFileName = $this->hasGlobalProjectFilter() ? 'selected_projects' : 'all_projects';
+            $fileName = 'tickets_'.($this->selectedProject?->name ?? $globalFileName).'_'.now()->format('Y-m-d_H-i-s').'.xlsx';
             $fileName = Str::slug($fileName, '_').'.xlsx';
             $export = new TicketsExport($tickets, $selectedColumns);
             Excel::store($export, 'exports/'.$fileName, 'public');
@@ -533,5 +754,424 @@ class ProjectBoard extends Page
     public function canMoveTickets(): bool
     {
         return auth()->user()->can('update_ticket');
+    }
+
+    public function isGlobalBoard(): bool
+    {
+        return $this->boardMode === self::MODE_GLOBAL;
+    }
+
+    public function isProjectIndex(): bool
+    {
+        return $this->boardMode === self::MODE_INDEX;
+    }
+
+    public function boardTitle(): string
+    {
+        if ($this->selectedProject) {
+            return $this->selectedProject->name;
+        }
+
+        if ($this->hasGlobalProjectFilter()) {
+            return 'Selected Projects';
+        }
+
+        return 'All Projects';
+    }
+
+    public function projectFilterActionLabel(): string
+    {
+        if ($this->isProjectIndex()) {
+            return 'Selected Projects';
+        }
+
+        if ($this->hasGlobalProjectFilter()) {
+            return 'Projects ('.$this->globalProjectFilterCount().')';
+        }
+
+        return 'Projects';
+    }
+
+    public function selectedGlobalProjectBadges(): Collection
+    {
+        $projectIds = $this->normalizedGlobalProjectFilterIds($this->selectedGlobalProjectIds);
+
+        if (empty($projectIds)) {
+            return collect();
+        }
+
+        return $this->projects
+            ->whereIn('id', $projectIds)
+            ->map(fn (Project $project) => $this->projectBadge($project))
+            ->values();
+    }
+
+    public function hasGlobalProjectFilter(): bool
+    {
+        return $this->isGlobalBoard() && $this->globalProjectFilterCount() > 0;
+    }
+
+    public function globalProjectFilterCount(): int
+    {
+        return count($this->normalizedGlobalProjectFilterIds($this->selectedGlobalProjectIds));
+    }
+
+    public function getReadableTextColor(?string $color): string
+    {
+        $hex = ltrim($color ?: '#6B7280', '#');
+
+        if (strlen($hex) !== 6) {
+            return '#FFFFFF';
+        }
+
+        $red = hexdec(substr($hex, 0, 2));
+        $green = hexdec(substr($hex, 2, 2));
+        $blue = hexdec(substr($hex, 4, 2));
+        $brightness = (($red * 299) + ($green * 587) + ($blue * 114)) / 1000;
+
+        return $brightness > 155 ? '#1F2937' : '#FFFFFF';
+    }
+
+    private function globalBoardColumns(): Collection
+    {
+        $projectIds = $this->visibleGlobalProjectIds();
+
+        if (empty($projectIds)) {
+            return collect();
+        }
+
+        $statusGroups = TicketStatus::query()
+            ->whereIn('project_id', $projectIds)
+            ->select('id', 'project_id', 'name', 'color', 'sort_order', 'is_completed')
+            ->orderBy('sort_order')
+            ->orderBy('name')
+            ->get()
+            ->groupBy('name')
+            ->sortBy(function (Collection $statuses, string $name) {
+                return str_pad((string) ($statuses->min('sort_order') ?? 0), 10, '0', STR_PAD_LEFT).'_'.$name;
+            });
+
+        return $statusGroups->map(function (Collection $statuses, string $statusName) {
+            $columnId = $this->globalColumnId($statusName);
+            $sortOrder = $this->sortOrders[$columnId] ?? 'due_date';
+            $statusIds = $statuses->pluck('id')->all();
+            $baseQuery = $this->globalTicketsQuery($statusIds);
+            $uniqueColors = $statuses->pluck('color')->filter()->unique()->values();
+            $projectBadges = $this->projects
+                ->whereIn('id', $statuses->pluck('project_id')->unique())
+                ->map(fn (Project $project) => $this->projectBadge($project))
+                ->values();
+
+            return (object) [
+                'id' => $columnId,
+                'name' => $statusName,
+                'color' => $uniqueColors->count() === 1 ? $uniqueColors->first() : '#4B5563',
+                'is_completed' => $statuses->contains(fn (TicketStatus $status) => $status->is_completed),
+                'project_ids' => $statuses->pluck('project_id')->unique()->values(),
+                'project_badges' => $projectBadges,
+                'project_count' => $statuses->pluck('project_id')->unique()->count(),
+                'tickets_count' => (clone $baseQuery)->count(),
+                'tickets' => $this->applyQuerySorting(
+                    (clone $baseQuery)
+                        ->with($this->ticketRelations())
+                        ->select($this->ticketSelectColumns()),
+                    $sortOrder
+                )
+                    ->limit($this->getColumnLimit($columnId))
+                    ->get(),
+            ];
+        })->values();
+    }
+
+    private function projectTicketsQuery(int $statusId): Builder
+    {
+        return Ticket::query()
+            ->where('project_id', $this->selectedProject->id)
+            ->where('ticket_status_id', $statusId)
+            ->when(! empty($this->selectedUserIds), function (Builder $query) {
+                $query->whereHas('assignees', function (Builder $assigneeQuery) {
+                    $assigneeQuery->whereIn('users.id', $this->selectedUserIds);
+                });
+            });
+    }
+
+    private function globalTicketsQuery(array $statusIds): Builder
+    {
+        return Ticket::query()
+            ->when(
+                empty($statusIds),
+                fn (Builder $query) => $query->whereRaw('1 = 0'),
+                fn (Builder $query) => $query->whereIn('ticket_status_id', $statusIds)
+            )
+            ->when(! empty($this->selectedUserIds), function (Builder $query) {
+                $query->whereHas('assignees', function (Builder $assigneeQuery) {
+                    $assigneeQuery->whereIn('users.id', $this->selectedUserIds);
+                });
+            });
+    }
+
+    private function accessibleProjectIds(): array
+    {
+        return $this->projects->pluck('id')->all();
+    }
+
+    private function visibleGlobalProjectIds(): array
+    {
+        if (! $this->isGlobalBoard()) {
+            return [];
+        }
+
+        $filteredProjectIds = $this->normalizedGlobalProjectFilterIds($this->selectedGlobalProjectIds);
+
+        if (empty($filteredProjectIds)) {
+            return $this->accessibleProjectIds();
+        }
+
+        return $filteredProjectIds;
+    }
+
+    private function projectFilterOptionLabels(): array
+    {
+        return $this->projects
+            ->mapWithKeys(fn (Project $project) => [
+                $project->id => $this->projectFilterOptionLabel($project),
+            ])
+            ->toArray();
+    }
+
+    private function projectFilterOptionLabel(Project $project): string
+    {
+        $badge = $this->projectBadge($project);
+        $pinnedIcon = $badge['is_pinned']
+            ? sprintf(
+                '<span class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full" style="background-color: %s;" title="Pinned"><svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 text-white" viewBox="0 0 24 24" fill="currentColor"><path d="M16 9V4h1c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3z" /></svg></span>',
+                e($badge['color']),
+            )
+            : '';
+
+        return sprintf(
+            '<span class="flex min-w-0 items-center gap-2">%s<span class="shrink-0 rounded px-2 py-0.5 text-xs font-semibold" style="background-color: %s; color: %s;">%s</span><span class="min-w-0 truncate text-sm font-medium">%s</span></span>',
+            $pinnedIcon,
+            e($badge['color']),
+            e($badge['text_color']),
+            e($badge['code']),
+            e($badge['name']),
+        );
+    }
+
+    private function projectBadge(Project $project): array
+    {
+        $color = $this->safeProjectColor($project->color);
+
+        return [
+            'id' => $project->id,
+            'name' => $project->name,
+            'code' => $this->projectCode($project),
+            'color' => $color,
+            'is_pinned' => $project->is_pinned,
+            'text_color' => $this->getReadableTextColor($color),
+        ];
+    }
+
+    private function safeProjectColor(?string $color): string
+    {
+        return preg_match('/^#[0-9A-Fa-f]{6}$/', $color ?? '') ? $color : '#6B7280';
+    }
+
+    private function navigateToBoardUrl(?string $projectId = null): void
+    {
+        $url = $projectId === null
+            ? static::getUrl()
+            : static::getUrl(['project_id' => $projectId]);
+
+        $this->js("Livewire.navigate('{$url}')");
+    }
+
+    private function globalRouteParameter(): string
+    {
+        $projectIds = $this->normalizedGlobalProjectFilterIds($this->selectedGlobalProjectIds);
+
+        if (empty($projectIds)) {
+            return self::ALL_PROJECT_ROUTE;
+        }
+
+        return self::SELECTED_PROJECTS_ROUTE_PREFIX.implode(',', $projectIds);
+    }
+
+    private function selectedProjectIdsFromRoute(string $routeProjectId): array
+    {
+        $projectIds = Str::after($routeProjectId, self::SELECTED_PROJECTS_ROUTE_PREFIX);
+
+        return collect(preg_split('/[,-]+/', $projectIds) ?: [])
+            ->filter(fn (string $projectId) => ctype_digit($projectId))
+            ->map(fn (string $projectId) => (int) $projectId)
+            ->values()
+            ->all();
+    }
+
+    private function restorePersistedGlobalProjectFilter(): bool
+    {
+        $projectIds = session(self::SESSION_SELECTED_GLOBAL_PROJECT_IDS, []);
+
+        if (! is_array($projectIds)) {
+            $this->clearPersistedGlobalProjectFilter();
+
+            return false;
+        }
+
+        $projectIds = $this->normalizedGlobalProjectFilterIds($projectIds);
+
+        if (empty($projectIds)) {
+            $this->clearPersistedGlobalProjectFilter();
+
+            return false;
+        }
+
+        $this->selectSelectedProjects($projectIds, navigate: false);
+
+        return true;
+    }
+
+    private function persistGlobalProjectFilter(): void
+    {
+        $projectIds = $this->normalizedGlobalProjectFilterIds($this->selectedGlobalProjectIds);
+
+        if (empty($projectIds)) {
+            $this->clearPersistedGlobalProjectFilter();
+
+            return;
+        }
+
+        session([self::SESSION_SELECTED_GLOBAL_PROJECT_IDS => $projectIds]);
+    }
+
+    private function clearPersistedGlobalProjectFilter(): void
+    {
+        session()->forget(self::SESSION_SELECTED_GLOBAL_PROJECT_IDS);
+    }
+
+    private function normalizedGlobalProjectFilterIds(array $projectIds): array
+    {
+        $projectIds = $this->sanitizeProjectIds($projectIds);
+
+        if (count($projectIds) === count($this->accessibleProjectIds())) {
+            return [];
+        }
+
+        return $projectIds;
+    }
+
+    private function sanitizeProjectIds(array $projectIds): array
+    {
+        $accessibleProjectIds = collect($this->accessibleProjectIds())
+            ->map(fn ($projectId) => (int) $projectId)
+            ->values();
+
+        return collect($projectIds)
+            ->map(fn ($projectId) => (int) $projectId)
+            ->unique()
+            ->filter(fn (int $projectId) => $accessibleProjectIds->containsStrict($projectId))
+            ->values()
+            ->all();
+    }
+
+    private function resolveTargetStatus(Ticket $ticket, string $targetStatusId): ?TicketStatus
+    {
+        if (is_numeric($targetStatusId)) {
+            return TicketStatus::query()
+                ->where('id', (int) $targetStatusId)
+                ->where('project_id', $ticket->project_id)
+                ->first();
+        }
+
+        $targetStatusName = $this->globalColumnName($targetStatusId);
+
+        if ($targetStatusName === null) {
+            return null;
+        }
+
+        return TicketStatus::query()
+            ->where('project_id', $ticket->project_id)
+            ->where('name', $targetStatusName)
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->first();
+    }
+
+    private function globalColumnId(string $statusName): string
+    {
+        return 'status:'.rtrim(strtr(base64_encode($statusName), '+/', '-_'), '=');
+    }
+
+    private function globalColumnName(string $columnId): ?string
+    {
+        if (! str_starts_with($columnId, 'status:')) {
+            return null;
+        }
+
+        $encoded = strtr(substr($columnId, strlen('status:')), '-_', '+/');
+        $encoded .= str_repeat('=', (4 - strlen($encoded) % 4) % 4);
+        $decoded = base64_decode($encoded, true);
+
+        return $decoded === false ? null : $decoded;
+    }
+
+    public function projectCode(?Project $project): string
+    {
+        if (! $project) {
+            return 'PRJ';
+        }
+
+        if ($project->ticket_prefix) {
+            return $project->ticket_prefix;
+        }
+
+        $words = str($project->name)
+            ->replaceMatches('/[^A-Za-z0-9\s]/', ' ')
+            ->squish()
+            ->explode(' ')
+            ->filter();
+
+        if ($words->count() <= 1) {
+            return str($project->name)->upper()->substr(0, 4)->toString();
+        }
+
+        return $words
+            ->take(4)
+            ->map(fn (string $word) => str($word)->substr(0, 1)->upper()->toString())
+            ->implode('');
+    }
+
+    private function ticketRelations(): array
+    {
+        return [
+            'assignees:id,name',
+            'status:id,project_id,name,color,is_completed',
+            'priority:id,name,color',
+            'creator:id,name',
+            'project:id,name,ticket_prefix,color',
+        ];
+    }
+
+    private function ticketSelectColumns(): array
+    {
+        return [
+            'id',
+            'project_id',
+            'ticket_status_id',
+            'priority_id',
+            'name',
+            'description',
+            'uuid',
+            'due_date',
+            'created_at',
+            'updated_at',
+            'created_by',
+        ];
+    }
+
+    private function getColumnLimit(int|string $columnId): int
+    {
+        return $this->columnLimits[(string) $columnId] ?? self::DEFAULT_COLUMN_LIMIT;
     }
 }

--- a/app/Filament/Pages/ProjectBoard.php
+++ b/app/Filament/Pages/ProjectBoard.php
@@ -5,15 +5,22 @@ namespace App\Filament\Pages;
 use App\Exports\TicketsExport;
 use App\Filament\Actions\ExportTicketsAction;
 use App\Filament\Resources\Tickets\TicketResource;
+use App\Models\Epic;
 use App\Models\Project;
 use App\Models\Ticket;
+use App\Models\TicketPriority;
 use App\Models\TicketStatus;
 use App\Models\User;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\DatePicker;
+use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Schemas\Schema;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
@@ -410,6 +417,11 @@ class ProjectBoard extends Page
     {
         $this->loadTicketStatuses();
         $this->dispatch('ticket-updated');
+
+        Notification::make()
+            ->title('Board Refreshed')
+            ->success()
+            ->send();
     }
 
     public function showTicketDetails(int $ticketId): void
@@ -425,7 +437,7 @@ class ProjectBoard extends Page
             return;
         }
 
-        $url = TicketResource::getUrl('view', ['record' => $ticketId]);
+        $url = $this->ticketViewUrl($ticketId);
         $this->js("window.open('{$url}', '_blank')");
     }
 
@@ -458,12 +470,25 @@ class ProjectBoard extends Page
                 ->name('ticket_on_board')
                 ->label('New Ticket')
                 ->icon('heroicon-m-plus')
-                ->visible(fn () => $this->selectedProject !== null && auth()->user()->can('create_ticket'))
-                ->schema(fn ($schema) => TicketResource::form($schema)
-                    ->columns(3)
-                )
+                ->visible(fn () => ! $this->isProjectIndex() && auth()->user()->can('create_ticket'))
+                ->schema(function ($schema) {
+                    // When in global board mode, we need a project selector first
+                    if ($this->isGlobalBoard()) {
+                        return $this->globalBoardTicketForm($schema);
+                    }
+
+                    return TicketResource::form($schema)->columns(3);
+                })
                 ->model(Ticket::class)
                 ->fillForm(function () {
+                    if ($this->isGlobalBoard()) {
+                        return [
+                            'project_id' => null,
+                            'ticket_status_id' => null,
+                            'assignees' => [],
+                        ];
+                    }
+
                     $assignees = [];
 
                     // Auto-assign current user if they're a project member
@@ -477,22 +502,36 @@ class ProjectBoard extends Page
                         'ticket_status_id' => $this->ticketStatuses?->first()?->id,
                         'assignees' => $assignees,
                     ];
-
                 })
                 ->action(function (array $data, $schema) {
                     $data['created_by'] = auth()->id();
 
-                    $model = $schema->getModel();
+                    // Extract assignees — not a DB column, handle separately
+                    $assigneeIds = $data['assignees'] ?? [];
+                    unset($data['assignees']);
 
+                    $model = $schema->getModel();
                     $record = $model::create($data);
 
-                    $schema->model($record)->saveRelationships();
+                    // Sync assignees to pivot table
+                    if (! empty($assigneeIds)) {
+                        $record->assignees()->sync($assigneeIds);
+                    } elseif (! empty($data['project_id'])) {
+                        // Auto-assign current user if they're a project member
+                        $project = Project::find($data['project_id']);
+                        if ($project && $project->members()->where('users.id', auth()->id())->exists()) {
+                            $record->assignees()->sync([auth()->id()]);
+                        }
+                    }
 
                     Notification::make()
                         ->title('Ticket Created')
                         ->body('The ticket has been created successfully.')
                         ->success()
                         ->send();
+
+                    $this->loadTicketStatuses();
+                    $this->dispatch('ticket-updated');
                 }),
 
             Action::make('refresh_board')
@@ -764,6 +803,30 @@ class ProjectBoard extends Page
     public function isProjectIndex(): bool
     {
         return $this->boardMode === self::MODE_INDEX;
+    }
+
+    public function ticketViewUrl(int $ticketId): string
+    {
+        $parameters = ['record' => $ticketId];
+
+        if ($from = $this->currentBoardRouteParameter()) {
+            $parameters['from'] = $from;
+        }
+
+        return TicketResource::getUrl('view', $parameters);
+    }
+
+    private function currentBoardRouteParameter(): ?string
+    {
+        if ($this->isGlobalBoard()) {
+            return str_replace(',', '-', $this->globalRouteParameter());
+        }
+
+        if ($this->selectedProjectId) {
+            return (string) $this->selectedProjectId;
+        }
+
+        return null;
     }
 
     public function boardTitle(): string
@@ -1173,5 +1236,126 @@ class ProjectBoard extends Page
     private function getColumnLimit(int|string $columnId): int
     {
         return $this->columnLimits[(string) $columnId] ?? self::DEFAULT_COLUMN_LIMIT;
+    }
+
+    private function globalBoardTicketForm(Schema $schema): Schema
+    {
+        // Resolve which project IDs are visible based on current filter
+        $visibleProjectIds = $this->visibleGlobalProjectIds();
+
+        $projectOptions = $this->projects
+            ->when(
+                ! empty($visibleProjectIds),
+                fn (Collection $projects) => $projects->whereIn('id', $visibleProjectIds)
+            )
+            ->pluck('name', 'id')
+            ->toArray();
+
+        return $schema
+            ->columns(3)
+            ->components([
+                Select::make('project_id')
+                    ->label('Project')
+                    ->options($projectOptions)
+                    ->required()
+                    ->searchable()
+                    ->live()
+                    ->afterStateUpdated(function (callable $set) {
+                        $set('ticket_status_id', null);
+                        $set('assignees', []);
+                        $set('epic_id', null);
+                    })
+                    ->columnSpanFull(),
+
+                Select::make('ticket_status_id')
+                    ->label('Status')
+                    ->options(function (callable $get) {
+                        $projectId = $get('project_id');
+                        if (! $projectId) {
+                            return [];
+                        }
+
+                        return TicketStatus::where('project_id', $projectId)
+                            ->pluck('name', 'id')
+                            ->toArray();
+                    })
+                    ->required()
+                    ->searchable()
+                    ->hidden(fn (callable $get): bool => ! $get('project_id')),
+
+                Select::make('priority_id')
+                    ->label('Priority')
+                    ->options(TicketPriority::pluck('name', 'id')->toArray())
+                    ->searchable()
+                    ->nullable()
+                    ->hidden(fn (callable $get): bool => ! $get('project_id')),
+
+                Select::make('epic_id')
+                    ->label('Epic')
+                    ->options(function (callable $get) {
+                        $projectId = $get('project_id');
+                        if (! $projectId) {
+                            return [];
+                        }
+
+                        return Epic::where('project_id', $projectId)
+                            ->pluck('name', 'id')
+                            ->toArray();
+                    })
+                    ->searchable()
+                    ->nullable()
+                    ->hidden(fn (callable $get): bool => ! $get('project_id')),
+
+                TextInput::make('name')
+                    ->label('Ticket Name')
+                    ->required()
+                    ->maxLength(255)
+                    ->hidden(fn (callable $get): bool => ! $get('project_id'))
+                    ->columnSpanFull(),
+
+                Select::make('assignees')
+                    ->label('Assigned to')
+                    ->multiple()
+                    ->options(function (callable $get) {
+                        $projectId = $get('project_id');
+                        if (! $projectId) {
+                            return [];
+                        }
+
+                        $project = Project::find($projectId);
+                        if (! $project) {
+                            return [];
+                        }
+
+                        return $project->members()
+                            ->orderBy('name')
+                            ->pluck('name', 'users.id')
+                            ->toArray();
+                    })
+                    ->searchable()
+                    ->live()
+                    ->hidden(fn (callable $get): bool => ! $get('project_id'))
+                    ->helperText('Only project members can be assigned.'),
+
+                DatePicker::make('start_date')
+                    ->label('Start Date')
+                    ->default(now())
+                    ->nullable()
+                    ->hidden(fn (callable $get): bool => ! $get('project_id')),
+
+                DatePicker::make('due_date')
+                    ->label('Due Date')
+                    ->nullable()
+                    ->hidden(fn (callable $get): bool => ! $get('project_id')),
+
+                RichEditor::make('description')
+                    ->label('Description')
+                    ->fileAttachmentsDisk('public')
+                    ->fileAttachmentsDirectory('attachments')
+                    ->fileAttachmentsVisibility('public')
+                    ->nullable()
+                    ->hidden(fn (callable $get): bool => ! $get('project_id'))
+                    ->columnSpanFull(),
+            ]);
     }
 }

--- a/app/Filament/Resources/Tickets/Pages/ViewTicket.php
+++ b/app/Filament/Resources/Tickets/Pages/ViewTicket.php
@@ -17,6 +17,7 @@ use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 
 class ViewTicket extends ViewRecord
 {
@@ -40,7 +41,7 @@ class ViewTicket extends ViewRecord
             ->fillForm(function (array $arguments): array {
                 $comment = TicketComment::find($arguments['commentId']);
 
-                if (!$comment) {
+                if (! $comment) {
                     return [];
                 }
 
@@ -52,7 +53,7 @@ class ViewTicket extends ViewRecord
             ->action(function (array $data): void {
                 $comment = TicketComment::find($data['comment_id']);
 
-                if (!$comment) {
+                if (! $comment) {
                     Notification::make()
                         ->title('Comment not found')
                         ->danger()
@@ -61,7 +62,7 @@ class ViewTicket extends ViewRecord
                     return;
                 }
 
-                if ($comment->user_id !== auth()->id() && !auth()->user()->hasRole(['super_admin'])) {
+                if ($comment->user_id !== auth()->id() && ! auth()->user()->hasRole(['super_admin'])) {
                     Notification::make()
                         ->title('You do not have permission to edit this comment')
                         ->danger()
@@ -98,7 +99,7 @@ class ViewTicket extends ViewRecord
             ->action(function (array $arguments): void {
                 $comment = TicketComment::find($arguments['commentId']);
 
-                if (!$comment) {
+                if (! $comment) {
                     Notification::make()
                         ->title('Comment not found')
                         ->danger()
@@ -107,7 +108,7 @@ class ViewTicket extends ViewRecord
                     return;
                 }
 
-                if ($comment->user_id !== auth()->id() && !auth()->user()->hasRole(['super_admin'])) {
+                if ($comment->user_id !== auth()->id() && ! auth()->user()->hasRole(['super_admin'])) {
                     Notification::make()
                         ->title('You do not have permission to delete this comment')
                         ->danger()
@@ -134,8 +135,9 @@ class ViewTicket extends ViewRecord
 
         return preg_replace_callback($pattern, function ($matches) {
             $videoUrl = $matches[1];
+
             return '<video controls class="max-w-full rounded-lg my-2" style="max-height: 400px;">
-                    <source src="' . $videoUrl . '" type="video/' . pathinfo($videoUrl, PATHINFO_EXTENSION) . '">
+                    <source src="'.$videoUrl.'" type="video/'.pathinfo($videoUrl, PATHINFO_EXTENSION).'">
                     Your browser does not support the video tag.
                 </video>';
         }, $html);
@@ -153,11 +155,73 @@ class ViewTicket extends ViewRecord
                         || $ticket->assignees()->where('users.id', auth()->id())->exists();
                 }),
 
+            Action::make('copy_url')
+                ->label('Copy URL')
+                ->icon('heroicon-o-clipboard-document')
+                ->color('gray')
+                ->alpineClickHandler(fn () => $this->copyTicketUrlScript()),
+
             Action::make('back')
                 ->label('Back to Board')
                 ->color('gray')
-                ->url(fn() => ProjectBoard::getUrl(['project_id' => $this->record->project_id])),
+                ->url(fn () => $this->getBackToBoardUrl()),
         ];
+    }
+
+    private function getBackToBoardUrl(): string
+    {
+        $from = request()->query('from');
+
+        if (is_string($from)) {
+            if ($this->isProjectBoardRouteParameter($from)) {
+                return ProjectBoard::getUrl(['project_id' => $from]);
+            }
+
+            if ($this->isProjectBoardUrl($from)) {
+                return $from;
+            }
+        }
+
+        return ProjectBoard::getUrl(['project_id' => $this->record->project_id]);
+    }
+
+    private function getTicketUrl(): string
+    {
+        return TicketResource::getUrl('view', ['record' => $this->record]);
+    }
+
+    private function copyTicketUrlScript(): string
+    {
+        $url = str_replace(['\\', "'"], ['\\\\', "\\'"], $this->getTicketUrl());
+
+        return "(() => { const url = '{$url}'; const notify = (copied) => window.FilamentNotification && new FilamentNotification().title(copied ? 'Ticket URL copied' : 'Unable to copy ticket URL')[copied ? 'success' : 'danger']().send(); const fallback = () => { const textarea = document.createElement('textarea'); textarea.value = url; textarea.setAttribute('readonly', ''); textarea.style.position = 'fixed'; textarea.style.top = '-1000px'; textarea.style.left = '-1000px'; document.body.appendChild(textarea); textarea.select(); const copied = document.execCommand('copy'); textarea.remove(); notify(copied); }; if (navigator.clipboard && window.isSecureContext) { navigator.clipboard.writeText(url).then(() => notify(true)).catch(fallback); } else { fallback(); } })()";
+    }
+
+    private function isProjectBoardRouteParameter(string $from): bool
+    {
+        return $from === 'all-project'
+            || ctype_digit($from)
+            || preg_match('/^selected-projects-\d+(?:[,-]\d+)*$/', $from) === 1;
+    }
+
+    private function isProjectBoardUrl(string $url): bool
+    {
+        $boardUrl = ProjectBoard::getUrl();
+        $boardPath = parse_url($boardUrl, PHP_URL_PATH);
+        $fromPath = parse_url($url, PHP_URL_PATH);
+
+        if (! is_string($boardPath) || ! is_string($fromPath)) {
+            return false;
+        }
+
+        $fromHost = parse_url($url, PHP_URL_HOST);
+        $boardHost = parse_url($boardUrl, PHP_URL_HOST);
+
+        if (is_string($fromHost) && $fromHost !== '' && $fromHost !== request()->getHost() && $fromHost !== $boardHost) {
+            return false;
+        }
+
+        return $fromPath === $boardPath || Str::startsWith($fromPath, rtrim($boardPath, '/').'/');
     }
 
     public function infolist(Schema $schema): Schema
@@ -219,7 +283,7 @@ class ViewTicket extends ViewRecord
                                     ->label('Due Date')
                                     ->date('d M Y')
                                     ->icon('heroicon-o-calendar')
-                                    ->color(fn($record) => $record->due_date && $record->due_date->isPast() ? 'danger' : 'success'),
+                                    ->color(fn ($record) => $record->due_date && $record->due_date->isPast() ? 'danger' : 'success'),
                             ]),
                     ]),
 

--- a/app/Filament/Resources/Tickets/Pages/ViewTicket.php
+++ b/app/Filament/Resources/Tickets/Pages/ViewTicket.php
@@ -6,6 +6,7 @@ use App\Filament\Pages\ProjectBoard;
 use App\Filament\Resources\Tickets\TicketResource;
 use App\Models\Ticket;
 use App\Models\TicketComment;
+use App\Models\TicketStatus;
 use Filament\Actions\Action;
 use Filament\Actions\EditAction;
 use Filament\Forms\Components\Hidden;
@@ -16,7 +17,6 @@ use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
-use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
 
 class ViewTicket extends ViewRecord
@@ -24,6 +24,59 @@ class ViewTicket extends ViewRecord
     protected static string $resource = TicketResource::class;
 
     public ?int $editingCommentId = null;
+
+    public function canChangeStatus(): bool
+    {
+        $ticket = $this->getRecord();
+
+        return auth()->user()->hasRole(['super_admin'])
+            || $ticket->created_by === auth()->id()
+            || $ticket->assignees()->where('users.id', auth()->id())->exists();
+    }
+
+    public function updateStatus(int $statusId): void
+    {
+        $ticket = $this->getRecord();
+
+        if (! $this->canChangeStatus()) {
+            Notification::make()
+                ->title('You do not have permission to change this ticket status')
+                ->danger()
+                ->send();
+
+            return;
+        }
+
+        if ($ticket->ticket_status_id === $statusId) {
+            return;
+        }
+
+        $targetStatus = TicketStatus::query()
+            ->where('project_id', $ticket->project_id)
+            ->whereKey($statusId)
+            ->first();
+
+        if (! $targetStatus) {
+            Notification::make()
+                ->title('Status Not Found')
+                ->body("This ticket's project does not have that status.")
+                ->warning()
+                ->send();
+
+            return;
+        }
+
+        $ticket->update([
+            'ticket_status_id' => $targetStatus->id,
+        ]);
+
+        $ticket->load('status');
+
+        Notification::make()
+            ->title('Status changed to '.$targetStatus->name)
+            ->success()
+            ->send();
+    }
 
     public function editCommentAction(): Action
     {
@@ -256,16 +309,8 @@ class ViewTicket extends ViewRecord
                             ->schema([
                                 TextEntry::make('status.name')
                                     ->label('Status')
-                                    ->formatStateUsing(function ($record) {
-                                        $color = e($record->status?->color ?? '#6B7280');
-                                        $name = e($record->status?->name ?? 'Unknown');
-
-                                        return new HtmlString(<<<HTML
-                                        <span class="fi-badge fi-size-sm" style="color: #fff; background-color: {$color};">
-                                            {$name}
-                                        </span>
-                                    HTML);
-                                    }),
+                                    ->hiddenLabel()
+                                    ->view('filament.resources.ticket-resource.status-switcher'),
 
                                 TextEntry::make('assignees.name')
                                     ->label('Assigned To')

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -12,6 +12,25 @@
         'Segoe UI Symbol', 'Noto Color Emoji';
 }
 
+/* Prose link styles - ensure links in comments are visible */
+.prose a {
+    color: var(--color-primary-600, #4f46e5);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+}
+
+.dark .prose a {
+    color: var(--color-primary-400, #818cf8);
+}
+
+.prose a:hover {
+    color: var(--color-primary-800, #3730a3);
+}
+
+.dark .prose a:hover {
+    color: var(--color-primary-300, #a5b4fc);
+}
+
 /* View-only mode styles */
 .view-only-mode .ticket-card {
     cursor: default !important;

--- a/resources/views/filament/pages/project-board.blade.php
+++ b/resources/views/filament/pages/project-board.blade.php
@@ -923,7 +923,7 @@
                                         @endif
 
                                         <a
-                                            href="{{ \App\Filament\Resources\Tickets\TicketResource::getUrl('view', ['record' => $ticket->id]) }}"
+                                            href="{{ $this->ticketViewUrl($ticket->id) }}"
                                             target="_blank"
                                             rel="noopener noreferrer"
                                             onclick="

--- a/resources/views/filament/pages/project-board.blade.php
+++ b/resources/views/filament/pages/project-board.blade.php
@@ -1,216 +1,335 @@
 <x-filament-panels::page>
+    @if(! $this->isProjectIndex())
+    @php
+        $selectedProjectBadges = $this->selectedGlobalProjectBadges();
+    @endphp
 
-    {{-- Project Selector --}}
-    @if(!$selectedProject)
-        <div class="mb-6">
-            <x-filament::section>
-                <div class="mb-5">
-                    <h2 class="text-lg font-semibold text-gray-900 dark:text-white">
-                        Select Project
-                    </h2>
-                    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">
-                        Choose a project to view its board
-                    </p>
-                </div>
-
-                {{-- Search Bar --}}
-                <div class="mb-4">
-                    <div class="relative">
-                        <div class="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
-                            <svg class="w-5 h-5 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
-                            </svg>
-                        </div>
-                        <input
-                            type="text"
-                            wire:model.live.debounce.300ms="searchProject"
-                            placeholder="Search projects by name or prefix..."
-                            class="block w-full pl-10 pr-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                        />
-                        @if($searchProject)
-                            <button
-                                wire:click="$set('searchProject', '')"
-                                class="absolute inset-y-0 right-0 flex items-center pr-3 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-                            >
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                                </svg>
-                            </button>
-                        @endif
-                    </div>
-                </div>
-
-                @if($projects->isEmpty())
-                    <div class="flex flex-col items-center justify-center py-12 text-gray-500 dark:text-gray-400">
-                        <h3 class="text-base font-medium text-gray-900 dark:text-white mb-1">No Projects Available</h3>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">You don't have access to any projects yet.</p>
-                    </div>
-                @elseif($this->filteredProjects->isEmpty())
-                    <div class="flex flex-col items-center justify-center py-12 text-gray-500 dark:text-gray-400">
-                        <svg class="w-12 h-12 mb-3 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+    <div class="mb-4" x-data="{ open: false }">
+        <div class="relative" @click.away="open = false">
+            <button
+                @click="open = !open"
+                class="inline-flex max-w-full items-center gap-2 rounded-lg border-2 bg-white px-4 py-2.5 text-sm font-medium text-gray-900 transition-colors hover:bg-gray-50 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700"
+                style="border-color: {{ $selectedProject->color ?? '#D1D5DB' }};"
+            >
+                @if($selectedProject?->is_pinned)
+                    @php
+                        $pinColor = $selectedProject->color ?? '#6B7280';
+                    @endphp
+                    <span
+                        class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
+                        style="background-color: {{ $pinColor }};"
+                        title="Pinned"
+                    >
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 text-white" viewBox="0 0 24 24" fill="currentColor">
+                            <path d="M16 9V4h1c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3z" />
                         </svg>
-                        <h3 class="text-base font-medium text-gray-900 dark:text-white mb-1">No Projects Found</h3>
-                        <p class="text-sm text-gray-500 dark:text-gray-400">Try adjusting your search terms</p>
-                    </div>
-                @else
-                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
-                        @foreach($this->filteredProjects as $project)
-                            <button
-                                wire:click="selectProject({{ $project->id }})"
-                                class="relative p-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg hover:shadow-md transition-all text-left overflow-hidden"
-                                style="border-left: 4px solid {{ $project->color ?? '#6B7280' }};"
-                            >
-                                {{-- Pin Icon Badge --}}
-                                @if($project->is_pinned)
-                                    <div class="absolute top-2 right-2">
-                                        <div class="flex items-center justify-center w-6 h-6 rounded-full shadow-sm"
-                                             style="background-color: {{ $project->color ?? '#6B7280' }};"
-                                             title="Pinned Project">
-                                            <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-white" viewBox="0 0 24 24" fill="currentColor">
-                                                <path d="M16 9V4h1c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3z"/>
-                                            </svg>
-                                        </div>
-                                    </div>
-                                @endif
-
-                                {{-- Project Prefix Badge --}}
-                                @if($project->ticket_prefix)
-                                    @php
-                                        $color = $project->color ?? '#6B7280';
-                                        // Convert hex to RGB
-                                        $hex = ltrim($color, '#');
-                                        $r = hexdec(substr($hex, 0, 2));
-                                        $g = hexdec(substr($hex, 2, 2));
-                                        $b = hexdec(substr($hex, 4, 2));
-                                        // Calculate brightness
-                                        $brightness = (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
-                                        // Use dark text for light colors, light text for dark colors
-                                        $textColor = $brightness > 155 ? '#1F2937' : '#FFFFFF';
-                                    @endphp
-                                    <div class="inline-flex px-2.5 py-1 rounded text-xs font-semibold mb-3"
-                                         style="background-color: {{ $color }}; color: {{ $textColor }};">
-                                        {{ $project->ticket_prefix }}
-                                    </div>
-                                @endif
-
-                                {{-- Project Name --}}
-                                <h3 class="font-semibold text-base text-gray-900 dark:text-white line-clamp-2">
-                                    {{ $project->name }}
-                                </h3>
-                            </button>
-                        @endforeach
-                    </div>
+                    </span>
                 @endif
-            </x-filament::section>
-        </div>
-    @else
-        {{-- Project Switcher --}}
-        <div class="mb-4" x-data="{ open: false }">
-            <div class="relative">
-                <button
-                    @click="open = !open"
-                    @click.away="open = false"
-                    class="inline-flex items-center gap-2 px-4 py-2.5 text-sm font-medium text-gray-900 dark:text-white bg-white dark:bg-gray-800 border-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
-                    style="border-color: {{ $selectedProject->color ?? '#D1D5DB' }};"
-                >
-                    @if($selectedProject->ticket_prefix)
-                        @php
-                            $color = $selectedProject->color ?? '#6B7280';
-                            $hex = ltrim($color, '#');
-                            $r = hexdec(substr($hex, 0, 2));
-                            $g = hexdec(substr($hex, 2, 2));
-                            $b = hexdec(substr($hex, 4, 2));
-                            $brightness = (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
-                            $textColor = $brightness > 155 ? '#1F2937' : '#FFFFFF';
-                        @endphp
-                        <span class="px-2 py-0.5 rounded text-xs font-semibold"
-                              style="background-color: {{ $color }}; color: {{ $textColor }};">
-                            {{ $selectedProject->ticket_prefix }}
-                        </span>
-                    @endif
-                    <span>{{ $selectedProject->name }}</span>
-                    <svg class="w-4 h-4 transition-transform" :class="{ 'rotate-180': open }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-                    </svg>
-                </button>
+                @if($selectedProject?->ticket_prefix)
+                    @php
+                        $color = $selectedProject->color ?? '#6B7280';
+                    @endphp
+                    <span
+                        class="rounded px-2 py-0.5 text-xs font-semibold"
+                        style="background-color: {{ $color }}; color: {{ $this->getReadableTextColor($color) }};"
+                    >
+                        {{ $selectedProject->ticket_prefix }}
+                    </span>
+                @elseif($this->isGlobalBoard())
+                    <span class="rounded bg-primary-100 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">
+                        {{ $this->hasGlobalProjectFilter() ? 'SEL' : 'ALL' }}
+                    </span>
+                @endif
 
-                {{-- Dropdown Menu --}}
-                <div
-                    x-show="open"
-                    x-transition:enter="transition ease-out duration-100"
-                    x-transition:enter-start="opacity-0 scale-95"
-                    x-transition:enter-end="opacity-100 scale-100"
-                    x-transition:leave="transition ease-in duration-75"
-                    x-transition:leave-start="opacity-100 scale-100"
-                    x-transition:leave-end="opacity-0 scale-95"
-                    class="absolute top-full left-0 mt-2 w-80 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 max-h-96 overflow-y-auto"
-                    style="display: none;"
-                >
-                    <div class="p-2">
-                        <div class="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                            Switch Project
+                <span class="truncate">{{ $this->boardTitle() }}</span>
+                @if($this->isGlobalBoard() && $this->hasGlobalProjectFilter())
+                    <span class="hidden rounded bg-primary-50 px-2 py-0.5 text-xs font-medium text-primary-700 dark:bg-primary-900/40 dark:text-primary-300 sm:inline">
+                        {{ $this->globalProjectFilterCount() }} selected
+                    </span>
+                @endif
+                <svg class="h-4 w-4 flex-shrink-0 transition-transform" :class="{ 'rotate-180': open }" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+            </button>
+
+            <div
+                x-show="open"
+                x-transition:enter="transition ease-out duration-100"
+                x-transition:enter-start="opacity-0 scale-95"
+                x-transition:enter-end="opacity-100 scale-100"
+                x-transition:leave="transition ease-in duration-75"
+                x-transition:leave-start="opacity-100 scale-100"
+                x-transition:leave-end="opacity-0 scale-95"
+                class="absolute left-0 top-full z-50 mt-2 max-h-96 w-80 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800"
+                style="display: none;"
+            >
+                <div class="p-2">
+                    <div class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        Project
+                    </div>
+
+                    <button
+                        wire:click="showProjectIndex"
+                        @click="open = false"
+                        class="mb-1 flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700"
+                    >
+                        <span class="rounded bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+                            LIST
+                        </span>
+                        <div class="min-w-0 flex-1 text-sm font-medium text-gray-900 dark:text-white">
+                            Project List
                         </div>
+                    </button>
+
+                    <button
+                        wire:click="selectAllProjects"
+                        @click="open = false"
+                        class="mb-1 flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 {{ $this->isGlobalBoard() && ! $this->hasGlobalProjectFilter() ? 'bg-gray-50 dark:bg-gray-700' : '' }}"
+                    >
+                        <span class="rounded bg-primary-100 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">
+                            ALL
+                        </span>
+                        <div class="min-w-0 flex-1 text-sm font-medium text-gray-900 dark:text-white">
+                            All Projects
+                        </div>
+                        @if($this->isGlobalBoard() && ! $this->hasGlobalProjectFilter())
+                            <svg class="h-4 w-4 flex-shrink-0 text-primary-600 dark:text-primary-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
+                            </svg>
+                        @endif
+                    </button>
+
+                    @if($selectedProjectBadges->isNotEmpty())
+                        <div class="mb-2 rounded-md bg-primary-50 px-3 py-2 dark:bg-primary-950/30">
+                            <div class="text-xs font-medium text-primary-700 dark:text-primary-300">
+                                Selected Projects
+                            </div>
+                            <div class="mt-2 flex flex-wrap gap-1.5">
+                                @foreach($selectedProjectBadges as $projectBadge)
+                                    <span
+                                        class="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                                        title="{{ $projectBadge['name'] }}"
+                                        style="background-color: {{ $projectBadge['color'] }}; color: {{ $projectBadge['text_color'] }};"
+                                    >
+                                        {{ $projectBadge['code'] }}
+                                    </span>
+                                @endforeach
+                            </div>
+                        </div>
+                    @endif
+
+                    <div class="mb-2 border-t border-gray-200 pt-2 dark:border-gray-700">
+                        <div class="relative">
+                            <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                                <svg class="h-4 w-4 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                                </svg>
+                            </div>
+                            <input
+                                type="text"
+                                wire:model.live.debounce.300ms="searchProject"
+                                placeholder="Search projects..."
+                                class="block w-full rounded-lg border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500"
+                            />
+                        </div>
+                    </div>
+
+                    @if($projects->isEmpty())
+                        <div class="px-3 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                            No projects available
+                        </div>
+                    @elseif($this->filteredProjects->isEmpty())
+                        <div class="px-3 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+                            No projects found
+                        </div>
+                    @else
                         @foreach($this->filteredProjects as $project)
                             <button
                                 wire:click="selectProject({{ $project->id }})"
                                 @click="open = false"
-                                class="w-full flex items-center gap-3 px-3 py-2 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors text-left {{ $project->id === $selectedProject->id ? 'bg-gray-50 dark:bg-gray-700' : '' }}"
+                                class="flex w-full items-center gap-3 rounded-md px-3 py-2 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700 {{ $selectedProject && $project->id === $selectedProject->id ? 'bg-gray-50 dark:bg-gray-700' : '' }}"
                             >
+                                @if($project->is_pinned)
+                                    <div
+                                        class="flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
+                                        style="background-color: {{ $project->color ?? '#6B7280' }};"
+                                        title="Pinned"
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3 w-3 text-white" viewBox="0 0 24 24" fill="currentColor">
+                                            <path d="M16 9V4h1c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3z" />
+                                        </svg>
+                                    </div>
+                                @endif
                                 @if($project->ticket_prefix)
                                     @php
                                         $color = $project->color ?? '#6B7280';
-                                        $hex = ltrim($color, '#');
-                                        $r = hexdec(substr($hex, 0, 2));
-                                        $g = hexdec(substr($hex, 2, 2));
-                                        $b = hexdec(substr($hex, 4, 2));
-                                        $brightness = (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
-                                        $textColor = $brightness > 155 ? '#1F2937' : '#FFFFFF';
                                     @endphp
-                                    <span class="px-2 py-0.5 rounded text-xs font-semibold"
-                                          style="background-color: {{ $color }}; color: {{ $textColor }};">
+                                    <span
+                                        class="rounded px-2 py-0.5 text-xs font-semibold"
+                                        style="background-color: {{ $color }}; color: {{ $this->getReadableTextColor($color) }};"
+                                    >
                                         {{ $project->ticket_prefix }}
                                     </span>
                                 @endif
-                                <div class="flex-1 min-w-0 text-sm font-medium text-gray-900 dark:text-white truncate">
+                                <div class="min-w-0 flex-1 truncate text-sm font-medium text-gray-900 dark:text-white">
                                     {{ $project->name }}
                                 </div>
-                                @if($project->id === $selectedProject->id)
-                                    <svg class="w-4 h-4 flex-shrink-0" style="color: {{ $project->color ?? '#3B82F6' }};" fill="currentColor" viewBox="0 0 20 20">
+                                @if($selectedProject && $project->id === $selectedProject->id)
+                                    <svg class="h-4 w-4 flex-shrink-0" style="color: {{ $project->color ?? '#3B82F6' }};" fill="currentColor" viewBox="0 0 20 20">
                                         <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"></path>
                                     </svg>
                                 @endif
                             </button>
                         @endforeach
-                    </div>
+                    @endif
                 </div>
             </div>
         </div>
+
+        @if($selectedProjectBadges->isNotEmpty())
+            <div class="mt-2 flex flex-wrap items-center gap-1.5">
+                <span class="text-xs font-medium text-gray-500 dark:text-gray-400">
+                    Selected:
+                </span>
+                @foreach($selectedProjectBadges as $projectBadge)
+                    <span
+                        class="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                        title="{{ $projectBadge['name'] }}"
+                        style="background-color: {{ $projectBadge['color'] }}; color: {{ $projectBadge['text_color'] }};"
+                    >
+                        {{ $projectBadge['code'] }}
+                    </span>
+                @endforeach
+            </div>
+        @endif
+    </div>
     @endif
 
-    @if($selectedProject)
+    @if($this->isProjectIndex())
+        <div class="space-y-4">
+            <div class="max-w-md">
+                <div class="relative">
+                    <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                        <svg class="h-4 w-4 text-gray-400 dark:text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                        </svg>
+                    </div>
+                    <input
+                        type="text"
+                        wire:model.live.debounce.300ms="searchProject"
+                        placeholder="Search projects..."
+                        class="block w-full rounded-lg border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-900 placeholder-gray-400 focus:border-transparent focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500"
+                    />
+                </div>
+            </div>
+
+            <div class="grid gap-3 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4">
+                <button
+                    type="button"
+                    wire:click="selectAllProjects"
+                    class="flex min-h-24 items-center gap-3 rounded-lg border border-primary-200 bg-white p-4 text-left transition-colors hover:border-primary-400 hover:bg-primary-50 dark:border-primary-800 dark:bg-gray-900 dark:hover:bg-primary-950/30"
+                >
+                    <span class="rounded bg-primary-100 px-2 py-0.5 text-xs font-semibold text-primary-700 dark:bg-primary-900/40 dark:text-primary-300">
+                        ALL
+                    </span>
+                    <div class="min-w-0 flex-1">
+                        <div class="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                            All Projects
+                        </div>
+                        <div class="text-xs text-gray-500 dark:text-gray-400">
+                            {{ $projects->count() }} projects
+                        </div>
+                    </div>
+                </button>
+
+                @if($projects->isEmpty())
+                    <div class="rounded-lg border border-dashed border-gray-300 p-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                        No projects available
+                    </div>
+                @elseif($this->filteredProjects->isEmpty())
+                    <div class="rounded-lg border border-dashed border-gray-300 p-6 text-sm text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                        No projects found
+                    </div>
+                @else
+                    @foreach($this->filteredProjects as $project)
+                        @php
+                            $color = $project->color ?? '#6B7280';
+                        @endphp
+                        <button
+                            type="button"
+                            wire:click="selectProject({{ $project->id }})"
+                            class="relative flex min-h-24 items-center gap-3 rounded-lg border border-gray-200 bg-white p-4 pr-10 text-left transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:hover:bg-gray-800"
+                            style="border-left-width: 4px; border-left-color: {{ $color }};"
+                        >
+                            @if($project->is_pinned)
+                                <div class="absolute right-2 top-2">
+                                    <div
+                                        class="flex h-6 w-6 items-center justify-center rounded-full shadow-sm"
+                                        style="background-color: {{ $color }};"
+                                        title="Pinned Project"
+                                    >
+                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-3.5 w-3.5 text-white" viewBox="0 0 24 24" fill="currentColor">
+                                            <path d="M16 9V4h1c.55 0 1-.45 1-1s-.45-1-1-1H7c-.55 0-1 .45-1 1s.45 1 1 1h1v5c0 1.66-1.34 3-3 3v2h5.97v7l1 1 1-1v-7H19v-2c-1.66 0-3-1.34-3-3z" />
+                                        </svg>
+                                    </div>
+                                </div>
+                            @endif
+                            @if($project->ticket_prefix)
+                                <span
+                                    class="rounded px-2 py-0.5 text-xs font-semibold"
+                                    style="background-color: {{ $color }}; color: {{ $this->getReadableTextColor($color) }};"
+                                >
+                                    {{ $project->ticket_prefix }}
+                                </span>
+                            @endif
+                            <div class="min-w-0 flex-1">
+                                <div class="truncate text-sm font-semibold text-gray-900 dark:text-white">
+                                    {{ $project->name }}
+                                </div>
+                            </div>
+                        </button>
+                    @endforeach
+                @endif
+            </div>
+        </div>
+    @elseif($selectedProject || $this->isGlobalBoard())
         <div
             x-data="{
                 draggingTicket: null,
+                draggingProjectId: null,
                 isTouchDevice: false,
                 touchStartX: 0,
                 touchStartY: 0,
                 scrollStartX: 0,
                 columnScrollPositions: {},
+                canMoveTickets: {{ $this->canMoveTickets() ? 'true' : 'false' }},
+                livewireComponentId: @js($this->getId()),
+                visibilityListenersAttached: false,
 
                 moveTicketToStatus(ticketId, statusId) {
-                    $wire.call('moveTicket', parseInt(ticketId), parseInt(statusId));
+                    const wire = window.Livewire?.find(this.livewireComponentId);
+
+                    if (!wire || typeof wire.$call !== 'function') {
+                        console.warn('Project Board Livewire component is not available for drag and drop.');
+                        return;
+                    }
+
+                    wire.$call('moveTicket', parseInt(ticketId, 10), statusId);
+                },
+
+                isTicketMovable(ticket) {
+                    return this.canMoveTickets && ticket?.dataset.canMove === 'true';
                 },
 
                 saveScrollPositions() {
-                    const columns = document.querySelectorAll('.status-column .overflow-y-auto');
+                    const columns = this.$el.querySelectorAll('.status-column .overflow-y-auto');
                     columns.forEach((column, index) => {
                         this.columnScrollPositions[index] = column.scrollTop;
                     });
                 },
 
                 restoreScrollPositions() {
-                    const columns = document.querySelectorAll('.status-column .overflow-y-auto');
+                    const columns = this.$el.querySelectorAll('.status-column .overflow-y-auto');
                     columns.forEach((column, index) => {
                         if (this.columnScrollPositions[index] !== undefined) {
                             column.scrollTop = this.columnScrollPositions[index];
@@ -218,23 +337,59 @@
                     });
                 },
 
+                isColumnAllowedForDraggedTicket(column) {
+                    if (!this.draggingProjectId) return true;
+
+                    const projectIds = column.getAttribute('data-project-ids');
+                    if (!projectIds) return true;
+
+                    return projectIds.split(',').includes(this.draggingProjectId);
+                },
+
+                updateColumnAvailability() {
+                    this.$el.querySelectorAll('.status-column').forEach(column => {
+                        if (this.isColumnAllowedForDraggedTicket(column)) {
+                            column.classList.remove('hidden');
+                            column.removeAttribute('title');
+                        } else {
+                            column.classList.add('hidden');
+                            column.setAttribute('title', 'This ticket project does not have this status');
+                        }
+                    });
+                },
+
+                resetColumnAvailability() {
+                    this.$el.querySelectorAll('.status-column').forEach(column => {
+                        column.classList.remove('hidden', 'bg-primary-50', 'dark:bg-primary-950');
+                        column.removeAttribute('title');
+                    });
+                },
+
                 init() {
                     this.$nextTick(() => {
-                        this.removeAllEventListeners();
-                        this.attachAllEventListeners();
                         this.setupTouchScrolling();
                         this.isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0;
                         this.setupPageVisibilityListener();
+                        if (this.canMoveTickets) {
+                            this.removeAllEventListeners();
+                            this.attachAllEventListeners();
+                        }
                     });
                 },
 
                 setupPageVisibilityListener() {
+                    if (this.visibilityListenersAttached) return;
+
+                    this.visibilityListenersAttached = true;
+
                     document.addEventListener('visibilitychange', () => {
                         if (!document.hidden) {
                             this.saveScrollPositions();
                             setTimeout(() => {
-                                this.removeAllEventListeners();
-                                this.attachAllEventListeners();
+                                if (this.canMoveTickets) {
+                                    this.removeAllEventListeners();
+                                    this.attachAllEventListeners();
+                                }
                                 this.restoreScrollPositions();
                             }, 100);
                         }
@@ -243,8 +398,10 @@
                     window.addEventListener('focus', () => {
                         this.saveScrollPositions();
                         setTimeout(() => {
-                            this.removeAllEventListeners();
-                            this.attachAllEventListeners();
+                            if (this.canMoveTickets) {
+                                this.removeAllEventListeners();
+                                this.attachAllEventListeners();
+                            }
                             this.restoreScrollPositions();
                         }, 100);
                     });
@@ -252,8 +409,10 @@
                     window.addEventListener('popstate', () => {
                         this.saveScrollPositions();
                         setTimeout(() => {
-                            this.removeAllEventListeners();
-                            this.attachAllEventListeners();
+                            if (this.canMoveTickets) {
+                                this.removeAllEventListeners();
+                                this.attachAllEventListeners();
+                            }
                             this.restoreScrollPositions();
                         }, 200);
                     });
@@ -261,8 +420,10 @@
                     document.addEventListener('livewire:navigated', () => {
                         this.saveScrollPositions();
                         setTimeout(() => {
-                            this.removeAllEventListeners();
-                            this.attachAllEventListeners();
+                            if (this.canMoveTickets) {
+                                this.removeAllEventListeners();
+                                this.attachAllEventListeners();
+                            }
                             this.restoreScrollPositions();
                         }, 300);
                     });
@@ -270,8 +431,10 @@
                     document.addEventListener('livewire:load', () => {
                         this.saveScrollPositions();
                         setTimeout(() => {
-                            this.removeAllEventListeners();
-                            this.attachAllEventListeners();
+                            if (this.canMoveTickets) {
+                                this.removeAllEventListeners();
+                                this.attachAllEventListeners();
+                            }
                             this.restoreScrollPositions();
                         }, 100);
                     });
@@ -279,8 +442,10 @@
                     document.addEventListener('livewire:updated', () => {
                         this.saveScrollPositions();
                         setTimeout(() => {
-                            this.removeAllEventListeners();
-                            this.attachAllEventListeners();
+                            if (this.canMoveTickets) {
+                                this.removeAllEventListeners();
+                                this.attachAllEventListeners();
+                            }
                             this.restoreScrollPositions();
                         }, 100);
                     });
@@ -288,8 +453,10 @@
                     window.addEventListener('ticket-updated', () => {
                         this.saveScrollPositions();
                         setTimeout(() => {
-                            this.removeAllEventListeners();
-                            this.attachAllEventListeners();
+                            if (this.canMoveTickets) {
+                                this.removeAllEventListeners();
+                                this.attachAllEventListeners();
+                            }
                             this.restoreScrollPositions();
                         }, 150);
                     });
@@ -304,23 +471,28 @@
                 },
 
                 ensureDragDropInitialized() {
-                    const tickets = document.querySelectorAll('.ticket-card');
+                    if (!this.canMoveTickets) return;
+
+                    const tickets = this.$el.querySelectorAll('.ticket-card');
                     let needsReinitialization = false;
 
                     tickets.forEach(ticket => {
-                        if (!ticket.getAttribute('draggable') || ticket.getAttribute('draggable') !== 'true') {
+                        if (this.isTicketMovable(ticket) && ticket.dataset.dragBound !== 'true') {
                             needsReinitialization = true;
                         }
                     });
 
                     if (needsReinitialization && tickets.length > 0) {
-                        this.removeAllEventListeners();
                         this.attachAllEventListeners();
                     }
                 },
 
                 setupTouchScrolling() {
-                    const container = document.getElementById('board-container');
+                    const container = this.$el;
+
+                    if (container.dataset.touchScrollingBound === 'true') return;
+
+                    container.dataset.touchScrollingBound = 'true';
 
                     container.addEventListener('touchstart', (e) => {
                         this.touchStartX = e.touches[0].clientX;
@@ -344,43 +516,44 @@
                 },
 
                 removeAllEventListeners() {
-                    const tickets = document.querySelectorAll('.ticket-card');
-                    tickets.forEach(ticket => {
-                        ticket.removeAttribute('draggable');
-                        const newTicket = ticket.cloneNode(true);
-                        ticket.parentNode.replaceChild(newTicket, ticket);
-                    });
-
-                    const columns = document.querySelectorAll('.status-column');
-                    columns.forEach(column => {
-                        const newColumn = column.cloneNode(false);
-                        while (column.firstChild) {
-                            newColumn.appendChild(column.firstChild);
-                        }
-                        if (column.parentNode) {
-                            column.parentNode.replaceChild(newColumn, column);
-                        }
-                    });
+                    this.resetColumnAvailability();
                 },
 
                 attachAllEventListeners() {
-                    @if(!$this->canMoveTickets())
-                        return;
-                    @endif
+                    if (!this.canMoveTickets) return;
 
-                    const tickets = document.querySelectorAll('.ticket-card');
+                    const tickets = this.$el.querySelectorAll('.ticket-card');
                     tickets.forEach(ticket => {
+                        if (!this.isTicketMovable(ticket)) {
+                            ticket.setAttribute('draggable', false);
+
+                            return;
+                        }
+
+                        if (ticket.dataset.dragBound === 'true') return;
+
+                        ticket.dataset.dragBound = 'true';
                         ticket.setAttribute('draggable', true);
 
                         ticket.addEventListener('dragstart', (e) => {
+                            if (!this.isTicketMovable(ticket)) {
+                                e.preventDefault();
+
+                                return;
+                            }
+
                             this.draggingTicket = ticket.getAttribute('data-ticket-id');
+                            this.draggingProjectId = ticket.getAttribute('data-ticket-project-id');
                             ticket.classList.add('opacity-50');
+                            this.updateColumnAvailability();
                             e.dataTransfer.effectAllowed = 'move';
                         });
 
                         ticket.addEventListener('dragend', () => {
                             ticket.classList.remove('opacity-50');
                             this.draggingTicket = null;
+                            this.draggingProjectId = null;
+                            this.resetColumnAvailability();
                         });
 
                         let longPressTimer;
@@ -388,13 +561,17 @@
                         let originalColumn;
 
                         ticket.addEventListener('touchstart', (e) => {
-                            if (isDragging) return;
+                            if (isDragging || !this.isTicketMovable(ticket)) return;
 
                             longPressTimer = setTimeout(() => {
+                                if (!this.isTicketMovable(ticket)) return;
+
                                 originalColumn = ticket.closest('.status-column');
                                 this.draggingTicket = ticket.getAttribute('data-ticket-id');
+                                this.draggingProjectId = ticket.getAttribute('data-ticket-project-id');
                                 ticket.classList.add('opacity-50', 'relative', 'z-30');
                                 isDragging = true;
+                                this.updateColumnAvailability();
                                 ticket.style.boxShadow = '0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05)';
                             }, 500);
                         }, { passive: true });
@@ -406,14 +583,15 @@
                             }
 
                             const touch = e.touches[0];
-                            const columns = document.querySelectorAll('.status-column');
+                            const columns = this.$el.querySelectorAll('.status-column');
 
                             columns.forEach(column => {
                                 const rect = column.getBoundingClientRect();
                                 if (touch.clientX >= rect.left &&
                                     touch.clientX <= rect.right &&
                                     touch.clientY >= rect.top &&
-                                    touch.clientY <= rect.bottom) {
+                                    touch.clientY <= rect.bottom &&
+                                    this.isColumnAllowedForDraggedTicket(column)) {
                                     column.classList.add('bg-primary-50', 'dark:bg-primary-950');
                                 } else {
                                     column.classList.remove('bg-primary-50', 'dark:bg-primary-950');
@@ -431,7 +609,7 @@
                             ticket.style.boxShadow = '';
 
                             const touch = e.changedTouches[0];
-                            const columns = document.querySelectorAll('.status-column');
+                            const columns = this.$el.querySelectorAll('.status-column');
 
                             let targetColumn = null;
                             columns.forEach(column => {
@@ -445,7 +623,7 @@
                                 column.classList.remove('bg-primary-50', 'dark:bg-primary-950');
                             });
 
-                            if (targetColumn && targetColumn !== originalColumn) {
+                            if (targetColumn && targetColumn !== originalColumn && this.isColumnAllowedForDraggedTicket(targetColumn)) {
                                 const statusId = targetColumn.getAttribute('data-status-id');
                                 const ticketId = this.draggingTicket;
 
@@ -453,6 +631,8 @@
                             }
 
                             this.draggingTicket = null;
+                            this.draggingProjectId = null;
+                            this.resetColumnAvailability();
                         });
 
                         ticket.addEventListener('touchcancel', () => {
@@ -463,16 +643,28 @@
                             ticket.classList.remove('opacity-50', 'relative', 'z-30');
                             ticket.style.boxShadow = '';
                             this.draggingTicket = null;
+                            this.draggingProjectId = null;
+                            this.resetColumnAvailability();
 
-                            document.querySelectorAll('.status-column').forEach(column => {
+                            this.$el.querySelectorAll('.status-column').forEach(column => {
                                 column.classList.remove('bg-primary-50', 'dark:bg-primary-950');
                             });
                         });
                     });
 
-                    const columns = document.querySelectorAll('.status-column');
+                    const columns = this.$el.querySelectorAll('.status-column');
                     columns.forEach(column => {
+                        if (column.dataset.dropBound === 'true') return;
+
+                        column.dataset.dropBound = 'true';
+
                         column.addEventListener('dragover', (e) => {
+                            if (!this.isColumnAllowedForDraggedTicket(column)) {
+                                e.dataTransfer.dropEffect = 'none';
+                                column.classList.remove('bg-primary-50', 'dark:bg-primary-950');
+                                return;
+                            }
+
                             e.preventDefault();
                             e.dataTransfer.dropEffect = 'move';
                             column.classList.add('bg-primary-50', 'dark:bg-primary-950');
@@ -486,10 +678,12 @@
                             e.preventDefault();
                             column.classList.remove('bg-primary-50', 'dark:bg-primary-950');
 
-                            if (this.draggingTicket) {
+                            if (this.draggingTicket && this.isColumnAllowedForDraggedTicket(column)) {
                                 const statusId = column.getAttribute('data-status-id');
                                 const ticketId = this.draggingTicket;
                                 this.draggingTicket = null;
+                                this.draggingProjectId = null;
+                                this.resetColumnAvailability();
                                 this.moveTicketToStatus(ticketId, statusId);
                             }
                         });
@@ -500,7 +694,7 @@
             @ticket-moved.window="init()"
             @ticket-updated.window="init()"
             @refresh-board.window="init()"
-            wire:key="board-container-{{ $selectedProject->id }}"
+            wire:key="board-container-{{ $selectedProject?->id ?? 'all-projects' }}"
             class="relative overflow-x-auto pb-6 {{ !$this->canMoveTickets() ? 'view-only-mode' : '' }}"
             id="board-container"
         >
@@ -535,6 +729,9 @@
                         wire:key="status-column-{{ $status->id }}"
                         class="status-column rounded-xl border border-gray-200 dark:border-gray-700 flex flex-col bg-gray-50 dark:bg-gray-900 w-[calc(85vw-2rem)] min-w-[280px] max-w-[350px] h-[700px] sm:w-[calc((100vw-6rem)/2)] sm:h-[750px] lg:w-[calc((100vw-8rem)/3)] lg:h-[800px] xl:w-[calc((100vw-10rem)/4)] xl:h-[850px]"
                         data-status-id="{{ $status->id }}"
+                        @if($this->isGlobalBoard() && isset($status->project_ids))
+                            data-project-ids="{{ $status->project_ids->implode(',') }}"
+                        @endif
                     >
                         <div
                             class="px-4 py-3 rounded-t-xl border-b border-gray-200 dark:border-gray-700 flex-shrink-0"
@@ -543,7 +740,7 @@
                             <div class="flex items-center justify-between">
                                 <h3 class="font-medium flex items-center gap-2" style="color: white; text-shadow: 0px 0px 1px rgba(0,0,0,0.5);">
                                     <span>{{ $status->name }}</span>
-                                    <span class="text-sm opacity-80">{{ $status->tickets->count() }}</span>
+                                    <span class="text-sm opacity-80">{{ $status->tickets_count ?? $status->tickets->count() }}</span>
                                     @if($status->is_completed)
                                         <div class="flex items-center justify-center w-6 h-6 bg-green-500 rounded-full border-2 border-white shadow-lg" title="Completed Status">
                                             <svg class="w-3 h-3 text-white font-bold" fill="currentColor" viewBox="0 0 20 20">
@@ -589,35 +786,35 @@
 
                                             <div class="py-1">
                                                 <button
-                                                    wire:click="setSortOrder({{ $status->id }}, 'date_created_newest')"
+                                                    wire:click="setSortOrder('{{ $status->id }}', 'date_created_newest')"
                                                     @click="open = false"
                                                     class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-white rounded"
                                                 >
                                                     Date created (newest first)
                                                 </button>
                                                 <button
-                                                    wire:click="setSortOrder({{ $status->id }}, 'date_created_oldest')"
+                                                    wire:click="setSortOrder('{{ $status->id }}', 'date_created_oldest')"
                                                     @click="open = false"
                                                     class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-white rounded"
                                                 >
                                                     Date created (oldest first)
                                                 </button>
                                                 <button
-                                                    wire:click="setSortOrder({{ $status->id }}, 'card_name_alphabetical')"
+                                                    wire:click="setSortOrder('{{ $status->id }}', 'card_name_alphabetical')"
                                                     @click="open = false"
                                                     class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-white rounded"
                                                 >
                                                     Card name (alphabetically)
                                                 </button>
                                                 <button
-                                                    wire:click="setSortOrder({{ $status->id }}, 'due_date')"
+                                                    wire:click="setSortOrder('{{ $status->id }}', 'due_date')"
                                                     @click="open = false"
                                                     class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-white rounded"
                                                 >
                                                     Due date
                                                 </button>
                                                 <button
-                                                    wire:click="setSortOrder({{ $status->id }}, 'priority')"
+                                                    wire:click="setSortOrder('{{ $status->id }}', 'priority')"
                                                     @click="open = false"
                                                     class="w-full text-left px-3 py-2 text-sm text-gray-700 dark:text-white rounded"
                                                 >
@@ -628,23 +825,55 @@
                                     </div>
                                 </div>
                             </div>
+                            @if($this->isGlobalBoard() && isset($status->project_badges))
+                                <div class="mt-2 flex flex-wrap gap-1">
+                                    @foreach($status->project_badges->take(6) as $projectBadge)
+                                        <span
+                                            class="rounded px-1.5 py-0.5 text-[10px] font-semibold shadow-sm"
+                                            style="background-color: {{ $projectBadge['color'] }}; color: {{ $projectBadge['text_color'] }};"
+                                        >
+                                            {{ $projectBadge['code'] }}
+                                        </span>
+                                    @endforeach
+                                    @if($status->project_badges->count() > 6)
+                                        <span class="rounded bg-white/20 px-1.5 py-0.5 text-[10px] font-semibold text-white">
+                                            +{{ $status->project_badges->count() - 6 }}
+                                        </span>
+                                    @endif
+                                </div>
+                            @endif
                         </div>
 
-                        <div class="p-3 flex flex-col gap-3 flex-1 overflow-y-auto" style="max-height: calc(100% - 60px);" x-data="{ visibleTickets: 10, totalTickets: {{ $status->tickets->count() }}, scrollPos: 0 }" x-init="$nextTick(() => { $el.addEventListener('scroll', () => { scrollPos = $el.scrollTop; if ($el.scrollTop + $el.clientHeight >= $el.scrollHeight - 100 && visibleTickets < totalTickets) { visibleTickets = Math.min(visibleTickets + 10, totalTickets); } }); })" x-ref="ticketContainer{{ $status->id }}">
-                            @foreach ($status->tickets as $index => $ticket)
+                        <div class="p-3 flex flex-col gap-3 flex-1 overflow-y-auto" style="max-height: calc(100% - 60px);">
+                            @foreach ($status->tickets as $ticket)
+                                @php
+                                    $canMoveTicket = $this->canMoveTicket($ticket);
+                                @endphp
                                 <div
                                     wire:key="ticket-{{ $status->id }}-{{ $ticket->id }}"
-                                    class="ticket-card bg-white dark:bg-gray-800 p-3 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 cursor-move"
+                                    class="ticket-card bg-white dark:bg-gray-800 p-3 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 {{ $canMoveTicket ? 'cursor-move' : 'cursor-default' }}"
                                     data-ticket-id="{{ $ticket->id }}"
-                                    x-show="{{ $index }} < visibleTickets"
-                                    x-transition:enter="transition ease-out duration-200"
-                                    x-transition:enter-start="opacity-0 transform scale-95"
-                                    x-transition:enter-end="opacity-100 transform scale-100"
+                                    data-ticket-project-id="{{ $ticket->project_id }}"
+                                    data-can-move="{{ $canMoveTicket ? 'true' : 'false' }}"
+                                    draggable="{{ $canMoveTicket ? 'true' : 'false' }}"
                                 >
-                                    <div class="flex justify-between items-center mb-2">
-                                        <span class="text-xs font-mono text-gray-500 dark:text-gray-400 px-1.5 py-0.5 bg-gray-100 dark:bg-gray-700 rounded truncate max-w-[120px] sm:max-w-none">
-                                            {{ $ticket->uuid }}
-                                        </span>
+                                    <div class="flex justify-between items-start gap-2 mb-2">
+                                        <div class="flex min-w-0 flex-wrap items-center gap-1">
+                                            @if($this->isGlobalBoard() && $ticket->project)
+                                                @php
+                                                    $projectColor = $ticket->project->color ?? '#6B7280';
+                                                @endphp
+                                                <span
+                                                    class="max-w-[120px] truncate rounded px-1.5 py-0.5 text-xs font-semibold"
+                                                    style="background-color: {{ $projectColor }}; color: {{ $this->getReadableTextColor($projectColor) }};"
+                                                >
+                                                    {{ $this->projectCode($ticket->project) }}
+                                                </span>
+                                            @endif
+                                            <span class="max-w-[130px] truncate rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-500 dark:bg-gray-700 dark:text-gray-400 sm:max-w-none">
+                                                {{ $ticket->uuid }}
+                                            </span>
+                                        </div>
                                         <div class="flex items-center gap-1">
                                             @if ($ticket->priority)
                                                 <span class="text-xs px-1.5 py-0.5 rounded whitespace-nowrap text-white font-medium" style="background-color: {{ $ticket->priority->color }};">
@@ -715,21 +944,26 @@
                                 </div>
                             @endforeach
 
-                            @if ($status->tickets->isEmpty())
+                            @php
+                                $loadedTickets = $status->tickets->count();
+                                $totalTickets = $status->tickets_count ?? $loadedTickets;
+                            @endphp
+
+                            @if ($loadedTickets === 0)
                                 <div class="flex items-center justify-center h-24 text-gray-500 dark:text-gray-400 text-sm italic border border-dashed border-gray-300 dark:border-gray-700 rounded-lg">
                                     No tickets
                                 </div>
-                            @else
-                                <!-- Loading indicator for more tickets -->
-                                <div x-show="visibleTickets < totalTickets" class="flex items-center justify-center py-4 text-gray-500 dark:text-gray-400 text-sm">
-                                    <div class="flex items-center gap-2">
-                                        <svg class="animate-spin h-4 w-4" fill="none" viewBox="0 0 24 24">
-                                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-                                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                                        </svg>
-                                        <span>Loading more tickets...</span>
-                                    </div>
-                                </div>
+                            @elseif($loadedTickets < $totalTickets)
+                                <button
+                                    type="button"
+                                    wire:click="loadMoreTickets('{{ $status->id }}')"
+                                    class="flex items-center justify-center rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+                                >
+                                    Load more
+                                    <span class="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
+                                        {{ $loadedTickets }} / {{ $totalTickets }}
+                                    </span>
+                                </button>
                             @endif
                         </div>
                     </div>
@@ -737,7 +971,7 @@
 
                 @if ($this->ticketStatuses->isEmpty())
                     <div class="w-full flex items-center justify-center h-40 text-gray-500 dark:text-gray-400">
-                        No status columns found for this project
+                        {{ $this->isGlobalBoard() ? 'No tickets found' : 'No status columns found for this project' }}
                     </div>
                 @endif
             </div>

--- a/resources/views/filament/resources/ticket-resource/comments-section.blade.php
+++ b/resources/views/filament/resources/ticket-resource/comments-section.blade.php
@@ -71,7 +71,10 @@
                                     @endif
                                 </div>
                             </div>
-                            <div class="prose prose-sm dark:prose-invert max-w-none">
+                            <div class="prose prose-sm dark:prose-invert max-w-none
+                                [&_a]:text-primary-600 [&_a]:underline [&_a]:underline-offset-2
+                                dark:[&_a]:text-primary-400
+                                [&_a:hover]:text-primary-800 dark:[&_a:hover]:text-primary-300">
                                 {!! convertVideoImgsToVideoTags($comment->comment) !!}
                             </div>
                             @if($comment->created_at != $comment->updated_at)

--- a/resources/views/filament/resources/ticket-resource/status-switcher.blade.php
+++ b/resources/views/filament/resources/ticket-resource/status-switcher.blade.php
@@ -1,0 +1,140 @@
+{{-- resources/views/filament/resources/ticket-resource/status-switcher.blade.php --}}
+
+@php
+    $record = $getRecord();
+    $statuses = \App\Models\TicketStatus::query()
+        ->where('project_id', $record->project_id)
+        ->orderBy('sort_order')
+        ->get();
+    $currentId = $record->ticket_status_id;
+    $current = $statuses->firstWhere('id', $currentId);
+    $currentColor = $current->color ?? '#6B7280';
+    $currentName = $current->name ?? 'Unknown';
+    $canChange = $this->canChangeStatus();
+@endphp
+
+<div class="ticket-status-switcher">
+    <dt class="fi-in-entry-label" style="display: block; margin-bottom: 0.5rem;">Status</dt>
+
+    @if ($canChange && $statuses->isNotEmpty())
+        <x-filament::dropdown placement="bottom-start" width="xs" wire:target="updateStatus">
+            <x-slot name="trigger">
+                <button
+                    type="button"
+                    wire:loading.attr="disabled"
+                    wire:target="updateStatus"
+                    class="tss-trigger"
+                    style="background-color: {{ $currentColor }};"
+                >
+                    <span class="tss-dot" style="background-color: rgba(255, 255, 255, .6);"></span>
+                    <span>{{ $currentName }}</span>
+                    <svg class="tss-chevron" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                        <path fill-rule="evenodd" d="M5.22 8.22a.75.75 0 0 1 1.06 0L10 11.94l3.72-3.72a.75.75 0 1 1 1.06 1.06l-4.25 4.25a.75.75 0 0 1-1.06 0L5.22 9.28a.75.75 0 0 1 0-1.06Z" clip-rule="evenodd" />
+                    </svg>
+                </button>
+            </x-slot>
+
+            <x-filament::dropdown.list>
+                @foreach ($statuses as $status)
+                    @php
+                        $isActive = $status->id === $currentId;
+                        $color = $status->color ?? '#6B7280';
+                    @endphp
+                    <x-filament::dropdown.list.item
+                        wire:click="updateStatus({{ $status->id }})"
+                        :disabled="$isActive"
+                    >
+                        <span class="tss-item">
+                            <span class="tss-dot" style="background-color: {{ $color }};"></span>
+                            <span class="tss-item-name">{{ $status->name }}</span>
+                            @if ($isActive)
+                                <svg class="tss-check" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                                    <path fill-rule="evenodd" d="M16.704 4.153a.75.75 0 0 1 .143 1.052l-8 10.5a.75.75 0 0 1-1.127.075l-4.5-4.5a.75.75 0 0 1 1.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 0 1 1.05-.143Z" clip-rule="evenodd" />
+                                </svg>
+                            @endif
+                        </span>
+                    </x-filament::dropdown.list.item>
+                @endforeach
+            </x-filament::dropdown.list>
+        </x-filament::dropdown>
+    @else
+        <span class="tss-trigger tss-trigger-static" style="background-color: {{ $currentColor }};">
+            <span class="tss-dot" style="background-color: rgba(255, 255, 255, .6);"></span>
+            <span>{{ $currentName }}</span>
+        </span>
+    @endif
+
+    <style>
+        .ticket-status-switcher .tss-trigger {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.375rem;
+            max-width: 100%;
+            padding: 0.125rem 0.5rem;
+            border-radius: 9999px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            line-height: 1.5;
+            white-space: nowrap;
+            color: #fff;
+            cursor: pointer;
+            border: none;
+            transition: filter .12s ease, transform .12s ease, box-shadow .12s ease;
+        }
+
+        .ticket-status-switcher .tss-trigger > span:not(.tss-dot) {
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+
+        .ticket-status-switcher button.tss-trigger:hover {
+            filter: brightness(1.06);
+            box-shadow: 0 1px 4px rgba(0, 0, 0, .2);
+        }
+
+        .ticket-status-switcher button.tss-trigger:active {
+            transform: translateY(1px);
+        }
+
+        .ticket-status-switcher button.tss-trigger:disabled {
+            cursor: wait;
+            opacity: .7;
+        }
+
+        .ticket-status-switcher .tss-trigger-static {
+            cursor: default;
+        }
+
+        .ticket-status-switcher .tss-chevron {
+            width: 12px;
+            height: 12px;
+            flex-shrink: 0;
+            opacity: .85;
+        }
+
+        .ticket-status-switcher .tss-dot {
+            width: 7px;
+            height: 7px;
+            border-radius: 50%;
+            flex-shrink: 0;
+        }
+
+        .ticket-status-switcher .tss-item {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            width: 100%;
+        }
+
+        .ticket-status-switcher .tss-item-name {
+            flex: 1;
+        }
+
+        .ticket-status-switcher .tss-check {
+            width: 16px;
+            height: 16px;
+            flex-shrink: 0;
+            color: rgb(107 114 128);
+        }
+    </style>
+</div>

--- a/resources/views/filament/resources/ticket-resource/timeline-history.blade.php
+++ b/resources/views/filament/resources/ticket-resource/timeline-history.blade.php
@@ -28,7 +28,26 @@
             width: 20px;
             height: 20px;
             border-radius: 50%;
-            background-color: #94a3b8;
+            border: 2px solid rgba(255,255,255,0.2);
+            box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
+        }
+
+        .timeline-history .status-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 2px 10px 2px 6px;
+            border-radius: 9999px;
+            font-size: 0.8rem;
+            font-weight: 600;
+            line-height: 1.5;
+        }
+
+        .timeline-history .status-badge-dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            flex-shrink: 0;
         }
     </style>
 
@@ -43,19 +62,32 @@
         {{-- Timeline items --}}
         <div class="space-y-5">
             @foreach($histories as $history)
+                @php
+                    $color = $history->status->color ?? '#94a3b8';
+                    // Convert hex to RGB for background with opacity
+                    $hex = ltrim($color, '#');
+                    $r = hexdec(substr($hex, 0, 2));
+                    $g = hexdec(substr($hex, 2, 2));
+                    $b = hexdec(substr($hex, 4, 2));
+                @endphp
                 <div class="timeline-item">
-                    {{-- Dot marker --}}
-                    <div class="timeline-dot"></div>
+                    {{-- Dot marker with status color --}}
+                    <div class="timeline-dot" style="background-color: {{ $color }};"></div>
                     
                     {{-- Content --}}
                     <div>
                         <div>
-                            <span class="text-base font-medium text-gray-900">{{ $history->status->name }}</span>
+                            {{-- Status badge with color --}}
+                            <span class="status-badge"
+                                style="background-color: {{ $color }}; color: #ffffff;">
+                                <span class="status-badge-dot" style="background-color: rgba(255,255,255,0.5);"></span>
+                                {{ $history->status->name }}
+                            </span>
                         </div>
                         
-                        <div class="text-xs text-gray-400 mt-1 flex items-center gap-x-1">
+                        <div class="text-xs text-gray-500 dark:text-gray-400 mt-1.5 flex items-center gap-x-1">
                             <span>Updated by: {{ $history->user->name ?? 'System' }}</span>
-                            <span class="text-gray-300 mx-1">•</span>
+                            <span class="text-gray-400 dark:text-gray-500 mx-1">•</span>
                             <span>{{ $history->created_at->format('d M H:i') }}</span>
                         </div>
                     </div>


### PR DESCRIPTION
Adds All Projects and Selected Projects modes to Project Board so users can review and manage tickets across accessible projects without switching boards one by one.

Changes:
- Add Project Board index with project list, All Projects, and selected-project URL modes
- Add persisted selected-project filtering with project code/color and pinned indicators
- Group global board columns by exact status name across selected projects
- Restrict drag/drop targets to statuses available for each ticket's project
- Show project code/color badges on global board columns and ticket cards
- Include project code/name columns automatically in global exports
- Use default cursor and disable drag listeners for tickets the user cannot move